### PR TITLE
fixed bug that autolocks everything

### DIFF
--- a/static/js/redux/actions/timetable_actions.jsx
+++ b/static/js/redux/actions/timetable_actions.jsx
@@ -149,7 +149,7 @@ export const lockTimetable = timetable => (dispatch, getState) => {
 };
 
 // load a personal timetable into state
-export const loadTimetable = (timetable, isLoadingNewTimetable = false) => (dispatch, getState) => {
+export const loadTimetable = (timetable, isLoadingNewTimetable = false, autoLockAll = true) => (dispatch, getState) => {
   const state = getState();
   const isLoggedIn = state.userInfo.data.isLoggedIn;
   if (!isLoggedIn) {
@@ -161,14 +161,20 @@ export const loadTimetable = (timetable, isLoadingNewTimetable = false) => (disp
     events: timetable.events.map(event =>
       ({ ...event, id: generateCustomEventId(), preview: false })),
   };
+  if(autoLockAll) {
+    dispatch({
+      type: ActionTypes.CHANGE_ACTIVE_SAVED_TIMETABLE,
+      timetable: displayTimetable,
+      upToDate: !isLoadingNewTimetable,
+    });
 
-  dispatch({
+    return dispatch(lockTimetable(displayTimetable));
+  }
+  return dispatch({
     type: ActionTypes.CHANGE_ACTIVE_SAVED_TIMETABLE,
     timetable: displayTimetable,
     upToDate: !isLoadingNewTimetable,
   });
-
-  return dispatch(lockTimetable(displayTimetable));
 };
 
 export const createNewTimetable = (ttName = 'Untitled Schedule') => (dispatch) => {

--- a/static/js/redux/actions/user_actions.jsx
+++ b/static/js/redux/actions/user_actions.jsx
@@ -137,7 +137,7 @@ export const fetchClassmates = timetable => (dispatch, getState) => {
     });
 };
 
-export const saveTimetable = (isAutoSave = false, callback = null) => (dispatch, getState) => {
+export const saveTimetable = (isAutoSave = false, callback = null, autoLockAll = false) => (dispatch, getState) => {
   const state = getState();
   if (!state.userInfo.data.isLoggedIn) {
     return dispatch({ type: ActionTypes.TOGGLE_SIGNUP_MODAL });
@@ -169,7 +169,7 @@ export const saveTimetable = (isAutoSave = false, callback = null) => (dispatch,
     .then(checkStatus)
     .then(response => response.json())
     .then((json) => {
-      dispatch(loadTimetable(json.saved_timetable));
+      dispatch(loadTimetable(json.saved_timetable, false, autoLockAll));
       dispatch({
         type: ActionTypes.RECEIVE_SAVED_TIMETABLES,
         timetables: json.timetables,


### PR DESCRIPTION
Clicking the lock icon always results in everything autolocking. Now if you unlock something, it stays unlocked. Essentially "saveTimeTable" by default, in line 172, redux/actions/user_actions.jsx, calls "loadTimetable" which then calls "lockTimetable" that locks everything. I added a parameter to control when lockTimetable gets called. By default, it is not called. Nothing further is done, the added parameter is just there in case later on, we want to autolock.