### PR TITLE
Search Bar UI Updates

### DIFF
--- a/static/css/timetable/partials/search_bar.scss
+++ b/static/css/timetable/partials/search_bar.scss
@@ -64,7 +64,7 @@
   background-color: #f2f3f5;
   border: 1px;
   border-radius: 25px;
-  color: $g777;
+  color: #757575;
   cursor: pointer;
   float: left;
   font-size: 14px;
@@ -89,11 +89,11 @@
   background-color: $gfff;
   border: 1px solid $ge6e6e6;
   box-shadow: 0 2px 10px $black-transparent-2;
-  color: $g777;
+  color: #777777;
   cursor: pointer;
   display: none;
   font-size: 14px;
-  max-width: 100px;
+  max-width: 95px;
   padding-bottom: 7px;
   padding-top: 7px;
   position: absolute;
@@ -105,8 +105,8 @@
   }
 
   .tip-border {
-    left: 0;
-    top: -8px;
+    left: 6;
+    top: -9px;
   }
 
   .tip {

--- a/static/css/timetable/partials/search_bar.scss
+++ b/static/css/timetable/partials/search_bar.scss
@@ -16,7 +16,7 @@
     height: 30px;
     line-height: 30px;
     outline: 0;
-    padding: 0 10px;
+    padding: 0 5px;
     width: 100%;
 
     &::-webkit-input-placeholder {
@@ -37,10 +37,6 @@
     &:-moz-placeholder { // Firefox 18-
       font-size: 14px;
       line-height: 30px;
-    }
-
-    &:focus {
-      border: 1px solid #0095FF;
     }
   }
 }
@@ -78,7 +74,7 @@
   margin-top: 0px;
   margin-bottom: 10px;
   margin-left: 0px;
-  padding: 6px 4px 6px 22px;
+  padding: 6px 4px 6px 30px;
   border-top-right-radius: 0px;
   border-bottom-right-radius: 0px;
 
@@ -101,7 +97,7 @@
   padding-bottom: 7px;
   padding-top: 7px;
   position: absolute;
-  top: 37px;
+  top: 30px;
   z-index: 100;
 
   &.down {

--- a/static/css/timetable/partials/social.scss
+++ b/static/css/timetable/partials/social.scss
@@ -32,12 +32,12 @@
 .tip-down {
   border-color: transparent;
   border-style: solid dashed dashed;
-  border-top-color: $primary-navy;
-  border-width: 6.5px 6.5px 0;
+  border-top-color: #777777;
+  border-width: 6.5px 5.5px 0;
   cursor: pointer;
   display: inline-block;
   height: 0;
-  margin-left: 5px;
+  margin-left: 10px;
   width: 0;
   z-index: 1;
 

--- a/static/css/timetable/partials/social.scss
+++ b/static/css/timetable/partials/social.scss
@@ -30,15 +30,12 @@
 }
 
 .tip-down {
-  border-color: transparent;
-  border-style: solid dashed dashed;
-  border-top-color: #777777;
-  border-width: 6.5px 5.5px 0;
-  cursor: pointer;
-  display: inline-block;
-  height: 0;
-  margin-left: 10px;
   width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 6px solid #777777;
+  margin-left: 10px;
   z-index: 1;
 
   &.down {
@@ -152,22 +149,18 @@
 }
 
 .tip-border {
-  border-color: transparent transparent $gccc;
-  border-style: dashed dashed solid;
-  border-width: 0 8.5px 8.5px;
-  height: 0;
-  position: absolute;
-  width: 0;
-  z-index: 1;
+  //if we want to add a tip shadow later
 }
 
 .tip {
-  border-color: transparent transparent $gfff;
-  border-style: dashed dashed solid;
-  border-width: 0 8.5px 8.5px;
-  height: 0;
-  position: absolute;
   width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-bottom: 8px solid #fff;
+  margin-left: 8px;
+  margin-top: -1px;
+  position: absolute;
   z-index: 1;
 }
 


### PR DESCRIPTION
- Hovering over search bar no longer results in a blue outline
- Fonts and font colors are now consistent
- Main drop-down triangle is now the same color as font 
- Secondary drop-down triangle is now white, with no border
- Width of drop down menu has been adjusted to reach the new dividing bar exactly

<img width="516" alt="screen shot 2019-02-04 at 6 11 30 pm" src="https://user-images.githubusercontent.com/36868381/52243673-5cea8180-28a8-11e9-9c76-08a5c881a45f.png">
<img width="518" alt="screen shot 2019-02-04 at 6 11 44 pm" src="https://user-images.githubusercontent.com/36868381/52243734-928f6a80-28a8-11e9-992d-4cce6614c760.png">
