### PR TITLE
Fixed search results errors

### DIFF
--- a/static/js/redux/actions/timetable_actions.jsx
+++ b/static/js/redux/actions/timetable_actions.jsx
@@ -242,7 +242,7 @@ export const loadCachedTimetable = (allSemesters, oldSemesters) => (dispatch, ge
     !cachedSemesterNotFound;
 
   if (!isCachedTimetableDataValid) { // switch back to default semester
-    dispatch(getUserSavedTimetables(allSemesters[0]));
+    dispatch(nullifyTimetable(dispatch));
   } else {
     let personalTimetablesExist = false;
     if (getState().userInfo.data.isLoggedIn) {

--- a/static/js/redux/ui/search_bar.jsx
+++ b/static/js/redux/ui/search_bar.jsx
@@ -27,6 +27,9 @@ class SearchBar extends React.Component {
   }
 
   static abbreviateSemesterName(semesterName) {
+    if (semesterName === 'Summer') {
+      return 'Su';
+    }
     return semesterName[0];
   }
 
@@ -130,6 +133,7 @@ class SearchBar extends React.Component {
       const name = ($(window).width() < 767) ?
                 SearchBar.getAbbreviatedSemesterName(semester) :
                 SearchBar.getSemesterName(semester);
+      console.log(name);
       return (
         <div
           key={name}

--- a/static/js/redux/ui/search_bar.jsx
+++ b/static/js/redux/ui/search_bar.jsx
@@ -133,7 +133,6 @@ class SearchBar extends React.Component {
       const name = ($(window).width() < 767) ?
                 SearchBar.getAbbreviatedSemesterName(semester) :
                 SearchBar.getSemesterName(semester);
-      console.log(name);
       return (
         <div
           key={name}


### PR DESCRIPTION
2 fixes
1. When user is not logged in and there's no cache, we should return a null tt instead of trying to get their saved tts. This was giving us a "unexpected char <.." because we return an html page instead of json.
2. Need unique keys for every element in the dom. We were using the "name" aka Spring 2019, Fall 2019, etc. On mobile these are simplified to S'19 and F'19. For Spring 2018 and Summer 2018 this produced an error of both simplifying to S'18. As a quick fix I made Summer 2018 --> Su'18 but we could maybe do something else later.