### PR TITLE
GCP Console: Added url verification tag

### DIFF
--- a/timetable/templates/index.html
+++ b/timetable/templates/index.html
@@ -36,6 +36,7 @@
 	      ga('send', 'pageview');
 
 	    </script>
+		<meta name="google-site-verification" content="A-t9Ubnq-7M8FVU4ImQIXnRFQwPR98UUDey5x_suvek" />
 	</head>
 	<body>
 		<header class="down">


### PR DESCRIPTION
- Not sure if this will fix the issue but GCP needs our home URL https://jhu.semester.ly/ verified 
- One of the ways to verify the URL is to add this tag