### PR TITLE
Changed to latest GitHub Repository Link

### DIFF
--- a/static/js/redux/ui/semesterly.jsx
+++ b/static/js/redux/ui/semesterly.jsx
@@ -203,7 +203,7 @@ class Semesterly extends React.Component {
                     className="footer-button--github"
                     target="_blank"
                     rel="noopener noreferrer"
-                    href="https://github.com/noahpresler/semesterly/"
+                    href="https://github.com/jhuopensource/semesterly"
                   >
                     <i className="fa fa-github" />
                     Follow


### PR DESCRIPTION
The footer of the schedule had the old semesterly repo link. Changed it to our current one.