### PR TITLE
Fix login with facebook after microsoft-django-auth delete

### DIFF
--- a/semesterly/settings.py
+++ b/semesterly/settings.py
@@ -162,7 +162,7 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
-    'django.contrib.sites',
+    # 'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'social_django',

--- a/student/urls.py
+++ b/student/urls.py
@@ -21,8 +21,7 @@ admin.autodiscover()
 
 urlpatterns = [
     # profile management
-    url(r'^user/logout/$', LogoutView.as_view(),
-        {'next_page': '/'}),
+    url(r'^user/logout/$', LogoutView.as_view(next_page='/')),
     url(r'^unsubscribe/(?P<id>[\w.@+-]+)/(?P<token>[\w.:\-_=]+)/$',
         student.views.unsubscribe),
     url(r'^user/settings/$', student.views.UserView.as_view()),


### PR DESCRIPTION
Oversight on my part for forgetting to remove django.contrib.sites. Fixes logout as well.