### PR TITLE
Forum views error handling

### DIFF
--- a/forum/views.py
+++ b/forum/views.py
@@ -87,10 +87,10 @@ class ForumTranscriptView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView
             Transcript, owner=student, semester=semester)
         advisor = get_object_or_404(Student, jhed=request.data['jhed'])
         if request.data['action'] == 'add':
-            if advisor not in transcript.advisors:
+            if advisor not in transcript.advisors.all():
                 transcript.advisors.add(advisor)
         elif request.data['action'] == 'remove':
-            if advisor in transcript.advisors:
+            if advisor in transcript.advisors.all():
                 transcript.advisors.remove(advisor)
         transcript.save()
 

--- a/forum/views.py
+++ b/forum/views.py
@@ -89,11 +89,11 @@ class ForumTranscriptView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView
             Transcript, owner=student, semester=semester)
         advisor = get_object_or_404(Student, jhed=request.data['jhed'])
         if request.data['action'] == 'add':
-            transcript.advisors.add(
-                Student.objects.get(jhed=request.data['jhed']))
+            if advisor not in transcript.advisors:
+                transcript.advisors.add(advisor)
         elif request.data['action'] == 'remove':
-            transcript.advisors.remove(
-                Student.objects.get(jhed=request.data['jhed']))
+            if advisor in transcript.advisors:
+                transcript.advisors.remove(advisor)
         transcript.save()
 
         return Response({'transcript': TranscriptSerializer(transcript).data},
@@ -102,7 +102,8 @@ class ForumTranscriptView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView
     def delete(self, request, sem_name, year):
         student = Student.objects.get(user=request.user)
         semester = Semester.objects.get(name=sem_name, year=year)
-        transcript = Transcript.objects.filter(owner=student, semester=semester)
+        transcript = Transcript.objects.filter(
+            owner=student, semester=semester)
         if transcript.exists():
             transcript.delete()
 

--- a/forum/views.py
+++ b/forum/views.py
@@ -12,7 +12,7 @@
 
 from __future__ import unicode_literals
 
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404
 from helpers.mixins import ValidateSubdomainMixin, RedirectToSignupMixin
 from student.models import Student
 from timetable.models import Semester
@@ -40,19 +40,22 @@ class ForumTranscriptView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView
     def get(self, request, sem_name, year):
         student = Student.objects.get(user=request.user)
         semester = Semester.objects.get(name=sem_name, year=year)
-        transcript = Transcript.objects.get(owner=student, semester=semester)
+        transcript = get_object_or_404(
+            Transcript, owner=student, semester=semester)
         return Response({'transcript': TranscriptSerializer(transcript).data},
                         status=status.HTTP_200_OK)
 
     def post(self, request, sem_name, year):
         student = Student.objects.get(user=request.user)
         semester = Semester.objects.get(name=sem_name, year=year)
-        transcript = Transcript.objects.get(owner=Student.objects.get(jhed=request.data['jhed']),
-                                            semester=semester)
+        transcript = get_object_or_404(
+            Transcript,
+            owner=Student.objects.get(jhed=request.data['jhed']),
+            semester=semester)
 
-        if ((not student in transcript.advisors.all()) and
-                (student.jhed != transcript.owner.jhed)):
-            return Response(status=status.HTTP_401_UNAUTHORIZED)
+        if student not in transcript.advisors.all() and \
+                student.jhed != transcript.owner.jhed:
+            return Response(status=status.HTTP_403_FORBIDDEN)
 
         comment = Comment.objects.create(author=student,
                                          content=request.data['content'],
@@ -60,28 +63,37 @@ class ForumTranscriptView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView
                                          transcript=transcript)
         comment.save()
 
-        return Response(status=status.HTTP_200_OK)
+        return Response(status=status.HTTP_201_CREATED)
 
     def put(self, request, sem_name, year):
         student = Student.objects.get(user=request.user)
         semester = Semester.objects.get(name=sem_name, year=year)
 
-        transcript = Transcript.objects.create(
+        transcript = Transcript.objects.filter(
             owner=student, semester=semester)
-        transcript.save()
+        if transcript.exists():
+            return Response(status=status.HTTP_409_CONFLICT)
+        else:
+            transcript = Transcript.objects.create(
+                owner=student, semseter=semester)
+            transcript.save()
 
         return Response({'transcript': TranscriptSerializer(transcript).data},
-                        status=status.HTTP_200_OK)
+                        status=status.HTTP_201_CREATED)
 
     def patch(self, request, sem_name, year):
         student = Student.objects.get(user=request.user)
         semester = Semester.objects.get(name=sem_name, year=year)
 
-        transcript = Transcript.objects.get(owner=student, semester=semester)
+        transcript = get_object_or_404(
+            Transcript, owner=student, semester=semester)
+        advisor = get_object_or_404(Student, jhed=request.data['jhed'])
         if request.data['action'] == 'add':
-            transcript.advisors.add(Student.objects.get(jhed=request.data['jhed']))
+            transcript.advisors.add(
+                Student.objects.get(jhed=request.data['jhed']))
         elif request.data['action'] == 'remove':
-            transcript.advisors.remove(Student.objects.get(jhed=request.data['jhed']))
+            transcript.advisors.remove(
+                Student.objects.get(jhed=request.data['jhed']))
         transcript.save()
 
         return Response({'transcript': TranscriptSerializer(transcript).data},
@@ -90,7 +102,8 @@ class ForumTranscriptView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView
     def delete(self, request, sem_name, year):
         student = Student.objects.get(user=request.user)
         semester = Semester.objects.get(name=sem_name, year=year)
-        transcript = Transcript.objects.get(owner=student, semester=semester)
-        transcript.delete()
+        transcript = Transcript.objects.filter(owner=student, semester=semester)
+        if transcript.exists():
+            transcript.delete()
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/forum/views.py
+++ b/forum/views.py
@@ -75,7 +75,7 @@ class ForumTranscriptView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView
             return Response(status=status.HTTP_409_CONFLICT)
         else:
             transcript = Transcript.objects.create(
-                owner=student, semseter=semester)
+                owner=student, semester=semester)
             transcript.save()
 
         return Response({'transcript': TranscriptSerializer(transcript).data},

--- a/forum/views.py
+++ b/forum/views.py
@@ -71,9 +71,7 @@ class ForumTranscriptView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView
 
         transcript = Transcript.objects.filter(
             owner=student, semester=semester)
-        if transcript.exists():
-            return Response(status=status.HTTP_409_CONFLICT)
-        else:
+        if not transcript.exists():
             transcript = Transcript.objects.create(
                 owner=student, semester=semester)
             transcript.save()


### PR DESCRIPTION
I decided to make it so that if the data provided is all valid, then the operation will continue smoothly. For example, if a transcript of an advisor (as provided by the JHED in the request data) doesn't exist, then the view will return a 404_NOT_FOUND. However, if the transcript and the advisor exist, then the view will return a 2xx status code even if nothing happened. Example: Let's say the request wanted to add an advisor, but the advisor is already added. Then it will return 200_OK, even though the advisor already exists and nothing was actually added. Please let me know if this kind of a silent fail is not what we want.