### PR TITLE
Advising view

### DIFF
--- a/advising/urls.py
+++ b/advising/urls.py
@@ -20,7 +20,7 @@ from helpers.mixins import FeatureFlowView
 app_name = 'advising'
 
 urlpatterns = [
-        #url(r'advising/$', advising.views.index),
-
-        url('advising/$',FeatureFlowView.as_view(feature_name='ADVISING')),
-    ]
+    url(r'^advising/*$', advising.views.AdvisingView.as_view()),
+    url(r'^advising/jhu_signup/*$',
+        FeatureFlowView.as_view(feature_name='JHU_SIGNUP')),
+]

--- a/advising/urls.py
+++ b/advising/urls.py
@@ -22,5 +22,5 @@ app_name = 'advising'
 urlpatterns = [
     url(r'^advising/*$', advising.views.AdvisingView.as_view()),
     url(r'^advising/jhu_signup/*$',
-        FeatureFlowView.as_view(feature_name='JHU_SIGNUP')),
+        FeatureFlowView.as_view(feature_name='JHU_SIGNUP', is_advising=True)),
 ]

--- a/advising/views.py
+++ b/advising/views.py
@@ -6,10 +6,10 @@ from student.utils import get_student
 from django.db import transaction
 
 from django.contrib.auth.mixins import LoginRequiredMixin
-from helpers.mixins import FeatureFlowView, ValidateSubdomainMixin, RedirectToJHUSignupMixin
+from helpers.mixins import FeatureFlowView, RedirectToJHUSignupMixin
 
 
-class AdvisingView(FeatureFlowView, ValidateSubdomainMixin, RedirectToJHUSignupMixin):
+class AdvisingView(RedirectToJHUSignupMixin, FeatureFlowView):
     is_advising = True
 
     def get_feature_flow(self, request, *args, **kwargs):

--- a/advising/views.py
+++ b/advising/views.py
@@ -5,10 +5,18 @@ from django.shortcuts import get_object_or_404, render, redirect
 from student.utils import get_student
 from django.db import transaction
 
-import semesterly.views
-
-# currently unused. TODO: add get_feature_flow()
-
-#feature_name = 'ADVISING'
+from django.contrib.auth.mixins import LoginRequiredMixin
+from helpers.mixins import FeatureFlowView, ValidateSubdomainMixin, RedirectToJHUSignupMixin
 
 
+class AdvisingView(FeatureFlowView, ValidateSubdomainMixin, RedirectToJHUSignupMixin):
+    feature_name = 'ADVISING'
+
+    def get_feature_flow(self, request, *args, **kwargs):
+        """
+        Return data needed for the feature flow for this HomeView.
+        A name value is automatically added in .get() using the feature_name class variable.
+        A semester value can also be provided, which will change the initial semester state of
+        the home page.
+        """
+        return {}    # TODO: Add required data

--- a/advising/views.py
+++ b/advising/views.py
@@ -7,10 +7,17 @@ from django.db import transaction
 
 from django.contrib.auth.mixins import LoginRequiredMixin
 from helpers.mixins import FeatureFlowView, RedirectToJHUSignupMixin
+from django.http import HttpResponseRedirect
 
 
 class AdvisingView(RedirectToJHUSignupMixin, FeatureFlowView):
     is_advising = True
+
+    def get(self, request, *args, **kwargs):
+        student = Student.objects.get(user=request.user)
+        if not student.jhed:
+            return HttpResponseRedirect('/advising/jhu_signup/')
+        return FeatureFlowView.get(self, request, *args, **kwargs)
 
     def get_feature_flow(self, request, *args, **kwargs):
         """

--- a/advising/views.py
+++ b/advising/views.py
@@ -10,7 +10,7 @@ from helpers.mixins import FeatureFlowView, ValidateSubdomainMixin, RedirectToJH
 
 
 class AdvisingView(FeatureFlowView, ValidateSubdomainMixin, RedirectToJHUSignupMixin):
-    feature_name = 'ADVISING'
+    is_advising = True
 
     def get_feature_flow(self, request, *args, **kwargs):
         """
@@ -19,4 +19,4 @@ class AdvisingView(FeatureFlowView, ValidateSubdomainMixin, RedirectToJHUSignupM
         A semester value can also be provided, which will change the initial semester state of
         the home page.
         """
-        return {}    # TODO: Add required data
+        return {}

--- a/forum/tests.py
+++ b/forum/tests.py
@@ -212,7 +212,10 @@ class ForumTranscriptViewTest(APITestCase):
 
     def test_create_transcript(self):
         setUpTranscriptDependencies(self)
-        request = self.factory.put('/advising/forum/Fall/2019/', format='json')
+        with self.assertRaises(Transcript.DoesNotExist):
+            transcript = Transcript.objects.get(
+                semester=self.semester, owner=self.student)
+        request = self.factory.get('/advising/forum/Fall/2019/', format='json')
         response = get_response_for_semester(self, request, self.student.user)
         self.assertEquals(response.status_code, status.HTTP_201_CREATED)
         transcript = Transcript.objects.get(

--- a/forum/views.py
+++ b/forum/views.py
@@ -53,10 +53,16 @@ class ForumTranscriptView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView
 
         student = Student.objects.get(user=request.user)
         semester = Semester.objects.get(name=sem_name, year=year)
-        transcript = get_object_or_404(
-            Transcript, owner=student, semester=semester)
-        return Response({'transcript': TranscriptSerializer(transcript).data},
-                        status=status.HTTP_200_OK)
+        transcript, created = Transcript.objects.get_or_create(
+            owner=student, semester=semester)
+        if created:
+            return Response(
+                {'transcript': TranscriptSerializer(transcript).data},
+                status=status.HTTP_201_CREATED)
+        else:
+            return Response(
+                {'transcript': TranscriptSerializer(transcript).data},
+                status=status.HTTP_200_OK)
 
     def post(self, request, sem_name, year):
         """Creates a new comment.
@@ -84,25 +90,6 @@ class ForumTranscriptView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView
         comment.save()
 
         return Response(status=status.HTTP_201_CREATED)
-
-    def put(self, request, sem_name, year):
-        """Creates a forum transcript associated with a certain semester.
-        Returns:
-            transcript: The new transcript.
-        """
-
-        student = Student.objects.get(user=request.user)
-        semester = Semester.objects.get(name=sem_name, year=year)
-
-        transcript = Transcript.objects.filter(
-            owner=student, semester=semester)
-        if not transcript.exists():
-            transcript = Transcript.objects.create(
-                owner=student, semester=semester)
-            transcript.save()
-
-        return Response({'transcript': TranscriptSerializer(transcript).data},
-                        status=status.HTTP_201_CREATED)
 
     def patch(self, request, sem_name, year):
         """Adds or removes one advisor from a forum transcript.

--- a/forum/views.py
+++ b/forum/views.py
@@ -13,7 +13,7 @@
 from __future__ import unicode_literals
 
 from django.shortcuts import get_object_or_404
-from helpers.mixins import ValidateSubdomainMixin, RedirectToSignupMixin
+from helpers.mixins import ValidateSubdomainMixin, RedirectToJHUSignupMixin
 from student.models import Student
 from timetable.models import Semester
 from forum.models import Transcript, Comment
@@ -23,7 +23,7 @@ from rest_framework.views import APIView
 from serializers import TranscriptSerializer, CommentSerializer
 
 
-class ForumView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView):
+class ForumView(ValidateSubdomainMixin, RedirectToJHUSignupMixin, APIView):
     """ Handles the accessing of all user forum transcripts. """
 
     def get(self, request):
@@ -41,7 +41,7 @@ class ForumView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView):
             status=status.HTTP_200_OK)
 
 
-class ForumTranscriptView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView):
+class ForumTranscriptView(ValidateSubdomainMixin, RedirectToJHUSignupMixin, APIView):
     """ Handles the accessing of individual user forum transcripts. """
 
     def get(self, request, sem_name, year):

--- a/helpers/mixins.py
+++ b/helpers/mixins.py
@@ -51,6 +51,7 @@ class FeatureFlowView(ValidateSubdomainMixin, APIView):
     """
     feature_name = None
     allow_unauthenticated = True
+    is_advising = False
 
     def get_feature_flow(self, request, *args, **kwargs):
         """
@@ -112,7 +113,8 @@ class FeatureFlowView(ValidateSubdomainMixin, APIView):
             'latestAgreement': AgreementSerializer(Agreement.objects.latest()).data,
             'registrar': SCHOOLS_MAP[self.school].registrar,
 
-            'featureFlow': dict(feature_flow, name=self.feature_name)
+            'featureFlow': dict(feature_flow, name=self.feature_name),
+            'isAdvising': self.is_advising
         }
 
         return render(request, 'timetable.html', {'init_data': json.dumps(init_data)})

--- a/helpers/mixins.py
+++ b/helpers/mixins.py
@@ -130,3 +130,8 @@ class CsrfExemptMixin:
 class RedirectToSignupMixin(LoginRequiredMixin):
     login_url = '/signup/'
     redirect_field_name = None
+
+
+class RedirectToJHUSignupMixin(LoginRequiredMixin):
+    login_url = '/advising/jhu_signup/'
+    redirect_field_name = None

--- a/static/js/redux/init.jsx
+++ b/static/js/redux/init.jsx
@@ -97,6 +97,9 @@ const handleFlows = featureFlow => (dispatch) => {
     case 'SIGNUP':
       dispatch({ type: ActionTypes.TRIGGER_SIGNUP_MODAL });
       break;
+    case 'JHU_SIGNUP':
+      dispatch({ type: ActionTypes.TRIGGER_JHU_SIGNUP_MODAL });
+      break;
     case 'USER_ACQ':
       dispatch({ type: ActionTypes.TRIGGER_ACQUISITION_MODAL });
       break;
@@ -160,9 +163,6 @@ const handleFlows = featureFlow => (dispatch) => {
     case 'SEPARATE_ACCOUNTS':
       dispatch({ type: ActionTypes.TRIGGER_SEPARATE_ACCOUNTS_MODAL });
       break;
-    case 'ADVISING':
-      advising = true;
-      break;
     default:
       // unexpected feature name
       break;
@@ -171,6 +171,7 @@ const handleFlows = featureFlow => (dispatch) => {
 
 const setup = () => (dispatch) => {
   initData = JSON.parse(initData);
+  advising = initData['isAdvising']
 
   dispatch({ type: ActionTypes.INIT_STATE, data: initData });
 

--- a/static/js/redux/ui/advising.jsx
+++ b/static/js/redux/ui/advising.jsx
@@ -19,6 +19,7 @@ import CommentForumContainer from './containers/comment_forum_container';
 import AdvisingScheduleContainer from './containers/advising_schedule_container';
 import UserSettingsModalContainer from './containers/modals/user_settings_modal_container';
 import SignupModalContainer from './containers/modals/signup_modal_container';
+import JHUSignupModalContainer from './containers/modals/jhu_signup_modal_container';
 import UserAcquisitionModalContainer from './containers/modals/user_acquisition_modal_container';
 
 
@@ -159,6 +160,7 @@ class Advising extends React.Component {
                 <UserSettingsModalContainer />
                 <UserAcquisitionModalContainer />
                 <SignupModalContainer />
+                <JHUSignupModalContainer />
                 <div className="all-cols">
                     <div className="main-advising">
                         <AdvisingScheduleContainer

--- a/static/js/redux/ui/modals/jhu_signup_modal.jsx
+++ b/static/js/redux/ui/modals/jhu_signup_modal.jsx
@@ -38,7 +38,7 @@ class JHUSignupModal extends React.Component {
   }
 
   hide() {
-    history.replaceState({}, 'Semester.ly', '/');
+    history.replaceState({}, 'Semester.ly', '/advising');
     this.props.toggleJHUSignupModal();
   }
 

--- a/static/js/redux/ui/modals/jhu_signup_modal.jsx
+++ b/static/js/redux/ui/modals/jhu_signup_modal.jsx
@@ -103,14 +103,18 @@ class JHUSignupModal extends React.Component {
               will not be shared with
               any other user without your permission.
             </div>
-            <a href="/login/azuread-tenant-oauth2?next=/advising">
-              <div className="signup-button">
-                Link JHED
-              </div>
-            </a>
+            <div className="signup-button"
+              onClick={() => {
+                const link = document.createElement('a');
+                link.href = `/login/azuread-tenant-oauth2/?next=/advising`;
+                document.body.appendChild(link);
+                link.click();
+              }}>
+              Link JHED
+            </div>
           </div>
-        </div>
-      </Modal>
+        </div >
+      </Modal >
     );
   }
 }

--- a/static/js/redux/ui/modals/jhu_signup_modal.jsx
+++ b/static/js/redux/ui/modals/jhu_signup_modal.jsx
@@ -103,13 +103,15 @@ class JHUSignupModal extends React.Component {
               will not be shared with
               any other user without your permission.
             </div>
-            <div className="signup-button"
+            <div
+              className="signup-button"
               onClick={() => {
                 const link = document.createElement('a');
-                link.href = `/login/azuread-tenant-oauth2/?next=/advising`;
+                link.href = '/login/azuread-tenant-oauth2/?next=/advising';
                 document.body.appendChild(link);
                 link.click();
-              }}>
+              }}
+            >
               Link JHED
             </div>
           </div>


### PR DESCRIPTION
1. If users now visit /advising without having connected JHED or without logging in, they are prompted to JHU login.
2. Some changes to FeatureFlowView in `mixins.py` and `init.jsx` so that using the AdvisingContainer no longer depends on the FeatureFlowView using name = "ADVISING" (This allows other modals to appear by using their own name).
3. Added RedirectToJHUSignupMixin
