### PR TITLE
Remove google calendar scope

### DIFF
--- a/semesterly/settings.py
+++ b/semesterly/settings.py
@@ -69,7 +69,7 @@ SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {
 
 SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE = [
     'https://www.googleapis.com/auth/userinfo.profile',
-    'https://www.googleapis.com/auth/calendar'
+    # 'https://www.googleapis.com/auth/calendar'
 ]
 SOCIAL_AUTH_GOOGLE_OAUTH2_AUTH_EXTRA_ARGUMENTS = {
     'access_type': 'offline',  # Enables the refreshing grant


### PR DESCRIPTION
It looks like we are still using some restricted calendar scope on Google Console 