### PR TITLE
Adjust SIS Post View

### DIFF
--- a/advising/views.py
+++ b/advising/views.py
@@ -88,7 +88,7 @@ class StudentSISView(ValidateSubdomainMixin, APIView):
             msg = 'Invalid token header. Token string should not contain invalid characters.'
             raise exceptions.AuthenticationFailed(msg)
         student = get_object_or_404(
-            Student, jhed=payload['StudentInfo']['JhedId'])
+            Student, jhed='{payload}{email}'.format(payload=payload['PersonalInfo']['JhedId'], email='@jh.edu')) 
         self.add_advisors(payload, student)
         self.add_majors(payload, student)
         self.add_minors(payload, student)
@@ -108,7 +108,7 @@ class StudentSISView(ValidateSubdomainMixin, APIView):
                 advisor.save()
 
     def add_majors(self, data, student):
-        student.primary_major = data['StudentInfo']['PrimaryMajor']
+        student.primary_major = data['PersonalInfo']['PrimaryMajor']
         del student.other_majors[:]
         for major_data in data['NonPrimaryMajors']:
             student.other_majors.append(major_data['Major'])
@@ -116,7 +116,7 @@ class StudentSISView(ValidateSubdomainMixin, APIView):
     def add_minors(self, data, student):
         del student.minors[:]
         for minor_data in data['Minors']:
-            student.minors.append(minor_data['Minor'])
+            student.minors.append(minor_data['MinorName'])
 
     def add_courses(self, data, student):
         student.sis_registered_sections.clear()

--- a/advising/views.py
+++ b/advising/views.py
@@ -101,7 +101,8 @@ class StudentSISView(ValidateSubdomainMixin, APIView):
         for advisor_data in data['Advisors']:
             last_name, first_name = advisor_data['FullName'].split(',')
             advisor, created = Advisor.objects.get_or_create(
-                jhed=advisor_data['JhedId'], email_address=advisor_data['EmailAddress'],
+                jhed='{payload}{email}'.format(payload=advisor_data['JhedId'], email='@jh.edu'), 
+                email_address=advisor_data['EmailAddress'],
                 last_name=last_name, first_name=first_name)
             if not created:
                 student.advisors.add(advisor)
@@ -130,7 +131,7 @@ class StudentSISView(ValidateSubdomainMixin, APIView):
             semester = get_object_or_404(Semester, name=name, year=year)
             section = get_object_or_404(
                 Section, course=course, semester=semester,
-                meeting_section="({})".format(course_data['SectionNumber']))
+                meeting_section="({})".format(course_data['Section']))
             student.sis_registered_sections.add(section)
 
 


### PR DESCRIPTION
Updated view since the JSON format will slightly deviate from our previous mock post.

The changes include 'StudentInfo' is now 'PersonalInfo' and 'Minor' is now 'MinorName' and jhed will be in the JSON without the '@jh.edu' tag which is necessary for our current database. Adjusted advisor jheds to same format and 'SectionName' to 'Section.'