### PR TITLE
Redirect Import SIS Button

### DIFF
--- a/static/js/redux/ui/modals/SIS_import_data_modal.jsx
+++ b/static/js/redux/ui/modals/SIS_import_data_modal.jsx
@@ -61,13 +61,12 @@ class SISImportDataModal extends React.Component {
         {modalHeader}
         {modalBody}
         <div className="go-to-sis__container">
-          <button
-            className="btn abnb-btn secondary" onClick={() => {
-
-            }}
+          <a
+            className="btn abnb-btn secondary"
+            href="https://self-dev.sis.jhu.edu/sandbox/sswf/go/?semesterlyexport=1"
           >
             <span>Import from SIS</span>
-          </button>
+          </a>
         </div>
       </Modal>
     );


### PR DESCRIPTION
SIS Import Button redirects to real link to connect SIS data with student.

Note: We may want to place this in our environment variables as well, but I'm not sure it's crucial at the moment since data can never be accessed without a valid JHED.