### PR TITLE
move autoSave dispatch to fix issues with timetable not updated

### DIFF
--- a/static/js/redux/actions/timetable_actions.jsx
+++ b/static/js/redux/actions/timetable_actions.jsx
@@ -111,6 +111,8 @@ export const fetchTimetables = (requestBody, removing, newActive = 0) => (dispat
       if (userData.isLoggedIn && json.timetables.length > 0 && userData.social_courses !== null) {
         dispatch(fetchClassmates(json.timetables[0]));
       }
+      // dispatch only after this promise resolves
+      dispatch(autoSave());
     });
 };
 
@@ -359,7 +361,6 @@ export const addOrRemoveCourse = (newCourseId, lockingSection = '') => (dispatch
   // and they're not trying to lock a new section).
   // otherwise, they're adding it
   dispatch(fetchTimetables(reqBody, removing));
-  dispatch(autoSave());
 };
 
 // fetch timetables with same courses, but updated optional courses/custom slots

--- a/static/js/redux/actions/user_actions.jsx
+++ b/static/js/redux/actions/user_actions.jsx
@@ -40,7 +40,6 @@ import { MAX_TIMETABLE_NAME_LENGTH } from '../constants/constants';
 import * as ActionTypes from '../constants/actionTypes';
 import { setTimeShownBanner, checkStatus, clearLocalTimetable } from '../util';
 
-let autoSaveTimer;
 
 export const receiveClassmates = json => dispatch => (
   dispatch({
@@ -341,17 +340,14 @@ export const fetchFriends = () => (dispatch, getState) => {
     });
 };
 
-export const autoSave = (delay = 2000) => (dispatch, getState) => {
-  clearTimeout(autoSaveTimer);
-  autoSaveTimer = setTimeout(() => {
-    const state = getState();
-    const existsSlots = getActiveTimetable(state).slots.length > 0;
-    const existsCustomEvents = state.customSlots.length > 0;
-    if (state.userInfo.data.isLoggedIn && (existsSlots || existsCustomEvents)) {
-      dispatch(saveTimetable(true));
-      clearLocalTimetable();
-    }
-  }, delay);
+export const autoSave = () => (dispatch, getState) => {
+  const state = getState();
+  const existsSlots = getActiveTimetable(state).slots.length > 0;
+  const existsCustomEvents = state.customSlots.length > 0;
+  if (state.userInfo.data.isLoggedIn && (existsSlots || existsCustomEvents)) {
+    dispatch(saveTimetable(true));
+    clearLocalTimetable();
+  }
 };
 
 export const sendRegistrationToken = token => (dispatch) => {


### PR DESCRIPTION
### Description
Move the location of `dispatch(autoSave)` to inside`fetchTimetables` to resolve the issue that the timetable is not updated if the backend does not respond within 2 seconds 
