### PR TITLE
Docs build requirements patch

### DIFF
--- a/build/semesterly-base/requirements_base.txt
+++ b/build/semesterly-base/requirements_base.txt
@@ -65,7 +65,6 @@ jsonfield==3.0.0
 jsonpatch==1.16
 jsonpointer==1.10
 jsonschema==3.2.0
-kombu==3.0.37
 livereload==2.5.1
 lxml==4.6.3
 mccabe==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,6 @@ jsonfield==3.0.0
 jsonpatch==1.16
 jsonpointer==1.10
 jsonschema==3.2.0
-kombu==3.0.37
 livereload==2.5.1
 lxml==4.6.3
 mccabe==0.6.1


### PR DESCRIPTION
### Description

Remove kombu, which depends on anyjson, which breaks build because it uses 2to3
