### PR TITLE
Timetable: Mark as not upToDate when name is changed

### DIFF
--- a/static/js/redux/state/slices/savingTimetableSlice.ts
+++ b/static/js/redux/state/slices/savingTimetableSlice.ts
@@ -37,6 +37,7 @@ const savingTimetableSlice = createSlice({
     },
     changeActiveSavedTimetableName: (state, action: PayloadAction<string>) => {
       state.activeTimetable.name = action.payload;
+      state.upToDate = false;
     },
   },
   extraReducers: (builder) => {


### PR DESCRIPTION
## Description
Fixes timetable name not being saved when changed

## Change Log
Set `upToDate` to false when timetable name is changed