### PR TITLE
Saving timetable: Remove updateExistingEvent as case for setting upToDate to false because it directly updates the event

### DIFF
--- a/static/js/redux/state/slices/savingTimetableSlice.ts
+++ b/static/js/redux/state/slices/savingTimetableSlice.ts
@@ -64,7 +64,6 @@ const savingTimetableSlice = createSlice({
           addNewCustomEvent,
           changeActiveTimetable,
           removeCustomEvent,
-          updateExistingEvent
         ),
         (state) => {
           state.upToDate = false;

--- a/static/js/redux/state/slices/savingTimetableSlice.ts
+++ b/static/js/redux/state/slices/savingTimetableSlice.ts
@@ -60,11 +60,7 @@ const savingTimetableSlice = createSlice({
         state.saving = false;
       })
       .addMatcher(
-        isAnyOf(
-          addNewCustomEvent,
-          changeActiveTimetable,
-          removeCustomEvent,
-        ),
+        isAnyOf(addNewCustomEvent, changeActiveTimetable, removeCustomEvent),
         (state) => {
           state.upToDate = false;
         }


### PR DESCRIPTION
Title