### PR TITLE
Saturday sunday/connect frontend backend

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 docs
 venv
+static/bundles

--- a/searches/views.py
+++ b/searches/views.py
@@ -107,7 +107,7 @@ class CourseSearchList(CsrfExemptMixin, ValidateSubdomainMixin, APIView):
                 "Thursday": "R",
                 "Friday": "F",
                 "Saturday": "S",
-                "Sunday": "U"
+                "Sunday": "U",
             }
             course_matches = course_matches.filter(
                 reduce(

--- a/static/css/timetable/partials/preference-modal.scss
+++ b/static/css/timetable/partials/preference-modal.scss
@@ -43,7 +43,7 @@
   }
 }
 
-.conflict-row {
+.preference-row {
   display: flex;
   padding: 2% 0;
 }

--- a/static/js/redux/__tests__/selectors.test.jsx
+++ b/static/js/redux/__tests__/selectors.test.jsx
@@ -20,6 +20,7 @@ describe("timetable selectors", () => {
   const timetable = {
     name: "tt_name",
     has_conflict: false,
+    show_weekend: true,
     slots: [
       {
         course: {

--- a/static/js/redux/actions/timetable_actions.jsx
+++ b/static/js/redux/actions/timetable_actions.jsx
@@ -211,7 +211,7 @@ export const createNewTimetable =
   };
 
 export const nullifyTimetable = () => (dispatch) => {
-  dispatch(receiveTimetables([{ slots: []}]));
+  dispatch(receiveTimetables([{ slots: [] }]));
   dispatch(courseSectionsActions.receiveCourseSections({}));
   dispatch(
     changeActiveSavedTimetable({

--- a/static/js/redux/actions/timetable_actions.jsx
+++ b/static/js/redux/actions/timetable_actions.jsx
@@ -197,12 +197,21 @@ export const createNewTimetable =
   (ttName = "Untitled Schedule") =>
   (dispatch) => {
     dispatch(
-      loadTimetable({ name: ttName, slots: [], events: [], has_conflict: false }, true)
+      loadTimetable(
+        {
+          name: ttName,
+          slots: [],
+          events: [],
+          has_conflict: false,
+          show_weekend: true,
+        },
+        true
+      )
     );
   };
 
 export const nullifyTimetable = () => (dispatch) => {
-  dispatch(receiveTimetables([{ slots: [], has_conflict: false }]));
+  dispatch(receiveTimetables([{ slots: []}]));
   dispatch(courseSectionsActions.receiveCourseSections({}));
   dispatch(
     changeActiveSavedTimetable({
@@ -211,6 +220,7 @@ export const nullifyTimetable = () => (dispatch) => {
         slots: [],
         events: [],
         has_conflict: false,
+        show_weekend: true,
       },
       upToDate: false,
     })

--- a/static/js/redux/actions/user_actions.jsx
+++ b/static/js/redux/actions/user_actions.jsx
@@ -529,7 +529,3 @@ export const handleAgreement = (currentUser, timeUpdatedTos) => (dispatch) => {
     }
   }
 };
-
-export const savePreferences = (dispatch, getState) => {
-  
-}

--- a/static/js/redux/actions/user_actions.jsx
+++ b/static/js/redux/actions/user_actions.jsx
@@ -69,6 +69,7 @@ const getSaveTimetablesRequestBody = (state) => {
     slots: tt.slots,
     events: state.customEvents.events,
     has_conflict: tt.has_conflict,
+    show_weekend: tt.show_weekend,
     semester: getCurrentSemester(state),
     name: state.savingTimetable.activeTimetable.name,
     id: state.savingTimetable.activeTimetable.id,

--- a/static/js/redux/actions/user_actions.jsx
+++ b/static/js/redux/actions/user_actions.jsx
@@ -529,3 +529,7 @@ export const handleAgreement = (currentUser, timeUpdatedTos) => (dispatch) => {
     }
   }
 };
+
+export const savePreferences = (dispatch, getState) => {
+  
+}

--- a/static/js/redux/constants/commonTypes.ts
+++ b/static/js/redux/constants/commonTypes.ts
@@ -76,6 +76,7 @@ export interface Timetable {
   id: number;
   slots: Slot[];
   has_conflict: boolean;
+  show_weekend: boolean;
   name: string;
   avg_rating: number;
   events: Event[];

--- a/static/js/redux/constants/constants.jsx
+++ b/static/js/redux/constants/constants.jsx
@@ -19,7 +19,15 @@ export const DAYS = ["M", "T", "W", "R", "F", "S", "U"];
 
 export const FULL_WEEK_LIST = ["U", "M", "T", "W", "R", "F", "S"];
 
-export const VERBOSE_DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+export const VERBOSE_DAYS = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+];
 
 export const DRAG_TYPES = {
   DRAG: "drag", // drag a custom slot to a new location

--- a/static/js/redux/constants/endpoints.jsx
+++ b/static/js/redux/constants/endpoints.jsx
@@ -28,6 +28,8 @@ export const getSaveTimetableEndpoint = () => "/user/timetables/";
 export const getUpdateEventEndpoint = () => "/user/events/";
 export const getDeleteTimetableEndpoint = (semester, name) =>
   `/user/timetables/${semester.name}/${semester.year}/${name}/`;
+export const getTimetablePreferencesEndpoint = (id) =>
+  `/user/timetables/${id}/preferences/`;
 export const getSaveSettingsEndpoint = () => "/user/settings/";
 export const getClassmatesEndpoint = (semester, courses) =>
   `/user/classmates/${semester.name}/${semester.year}?${$.param({

--- a/static/js/redux/state/slices/preferencesSlice.ts
+++ b/static/js/redux/state/slices/preferencesSlice.ts
@@ -1,6 +1,9 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { AppDispatch, getActiveTimetable, RootState } from "..";
 import { changeActiveSavedTimetable } from "../../actions";
 import { Timetable } from "../../constants/commonTypes";
+import { getTimetablePreferencesEndpoint } from "../../constants/endpoints";
+import Cookie from "js-cookie";
 
 interface PreferencesSliceState {
   tryWithConflicts: boolean;
@@ -58,15 +61,20 @@ const preferencesSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
-      builder.
-        addCase(changeActiveSavedTimetable, (state, action: PayloadAction<{
-        timetable: Timetable;
-        upToDate: boolean;
-      }>) => {
+    builder.addCase(
+      changeActiveSavedTimetable,
+      (
+        state,
+        action: PayloadAction<{
+          timetable: Timetable;
+          upToDate: boolean;
+        }>
+      ) => {
         state.tryWithConflicts = action.payload.timetable.has_conflict;
         state.showWeekend = action.payload.timetable.show_weekend;
-      });
-    }
+      }
+    );
+  },
 });
 export const preferencesActions = preferencesSlice.actions;
 

--- a/static/js/redux/state/slices/preferencesSlice.ts
+++ b/static/js/redux/state/slices/preferencesSlice.ts
@@ -14,12 +14,34 @@ const initialState: PreferencesSliceState = {
   isModalVisible: false,
 };
 
+export const savePreferences = (_dispatch: AppDispatch, getState: () => RootState) => {
+  const state = getState();
+  const activeTimetable = getActiveTimetable(state);
+  const preferences = state.preferences;
+  fetch(getTimetablePreferencesEndpoint(activeTimetable.id), {
+    headers: {
+      "X-CSRFToken": Cookie.get("csrftoken"),
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    method: "PUT",
+    body: JSON.stringify({
+      has_conflict: preferences.tryWithConflicts,
+      show_weekend: preferences.showWeekend,
+    }),
+    credentials: "include",
+  });
+};
+
 const preferencesSlice = createSlice({
   name: "preferences",
   initialState,
   reducers: {
-    togglePreferenceModal: (state) => {
-      state.isModalVisible = !state.isModalVisible;
+    showPreferenceModal: (state) => {
+      state.isModalVisible = true;
+    },
+    hidePreferenceModal: (state) => {
+      state.isModalVisible = false;
     },
     toggleConflicts: (state) => {
       state.tryWithConflicts = !state.tryWithConflicts;

--- a/static/js/redux/state/slices/preferencesSlice.ts
+++ b/static/js/redux/state/slices/preferencesSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { SearchMetrics } from "../../constants/commonTypes";
+import { changeActiveSavedTimetable } from "../../actions";
+import { Timetable } from "../../constants/commonTypes";
 
 interface PreferencesSliceState {
   tryWithConflicts: boolean;
@@ -34,6 +35,16 @@ const preferencesSlice = createSlice({
       state.showWeekend = payload.showWeekend;
     },
   },
+  extraReducers: (builder) => {
+      builder.
+        addCase(changeActiveSavedTimetable, (state, action: PayloadAction<{
+        timetable: Timetable;
+        upToDate: boolean;
+      }>) => {
+        state.tryWithConflicts = action.payload.timetable.has_conflict;
+        state.showWeekend = action.payload.timetable.show_weekend;
+      });
+    }
 });
 export const preferencesActions = preferencesSlice.actions;
 

--- a/static/js/redux/state/slices/savingTimetableSlice.ts
+++ b/static/js/redux/state/slices/savingTimetableSlice.ts
@@ -21,6 +21,7 @@ const initialState: SavingTimetableSliceState = {
     id: null,
     slots: [],
     has_conflict: null,
+    show_weekend: null,
     avg_rating: null,
     events: [],
   },

--- a/static/js/redux/state/slices/timetablesSlice.ts
+++ b/static/js/redux/state/slices/timetablesSlice.ts
@@ -28,6 +28,7 @@ interface TimetablesSliceState {
 const emptyTimetable: Timetable = {
   slots: [],
   has_conflict: false,
+  show_weekend: true,
   id: null,
   avg_rating: 0,
   events: [],

--- a/static/js/redux/ui/calendar.tsx
+++ b/static/js/redux/ui/calendar.tsx
@@ -56,7 +56,7 @@ const Row = (props: RowProps) => {
 };
 
 type CalendarProps = {
-  togglePreferenceModal: Function;
+  showPreferenceModal: Function;
   triggerSaveCalendarModal: Function;
   isFetchingShareLink: boolean;
   endHour: number;
@@ -306,7 +306,7 @@ const Calendar = (props: CalendarProps) => {
   const preferenceButton = (
     <div className="cal-btn-wrapper">
       <button
-        onClick={() => props.togglePreferenceModal()}
+        onClick={() => props.showPreferenceModal()}
         className="save-timetable"
         data-tip
         data-for="pref-btn-tooltip"

--- a/static/js/redux/ui/containers/calendar_container.jsx
+++ b/static/js/redux/ui/containers/calendar_container.jsx
@@ -21,7 +21,6 @@ import {
   fetchShareTimetableLink,
   fetchSISTimetableData,
 } from "../../actions/calendar_actions";
-import { togglePreferenceModal } from "../../actions/modal_actions";
 import { getMaxEndHour } from "../../state";
 import { saveCalendarModalActions } from "../../state/slices/saveCalendarModalSlice";
 import { preferencesActions } from "../../state/slices/preferencesSlice";
@@ -45,7 +44,7 @@ const mapStateToProps = (state) => {
 const CalendarContainer = connect(mapStateToProps, {
   saveTimetable,
   fetchShareTimetableLink,
-  togglePreferenceModal: preferencesActions.togglePreferenceModal,
+  showPreferenceModal: preferencesActions.showPreferenceModal,
   triggerSaveCalendarModal: saveCalendarModalActions.triggerSaveCalendarModal,
   createICalFromTimetable,
   handleCreateNewTimetable,

--- a/static/js/redux/ui/containers/day_calendar_container.jsx
+++ b/static/js/redux/ui/containers/day_calendar_container.jsx
@@ -42,7 +42,7 @@ const DayCalendarContainer = connect(mapStateToProps, {
   // NOTE: uses this syntax to avoid onClick accidentally passing a callback
   saveTimetable: () => saveTimetable(),
   fetchShareTimetableLink,
-  togglePreferenceModal: preferencesActions.togglePreferenceModal,
+  showPreferenceModal: preferencesActions.showPreferenceModal,
   triggerSaveCalendarModal: saveCalendarModalActions.toggleSaveCalendarModal,
   createICalFromTimetable,
   handleCreateNewTimetable,

--- a/static/js/redux/ui/day_calendar.tsx
+++ b/static/js/redux/ui/day_calendar.tsx
@@ -101,15 +101,11 @@ const DayCalendar = (props: DayCalendarProps) => {
   const mod = (n: number, m: number) => ((n % m) + m) % m;
 
   const swipedLeft = () => {
-    setCurrentDay((prev) => 
-      showWeekend ? mod(prev + 1, 7) : mod(prev + 1, 5);
-    );
+    setCurrentDay((prev) => (showWeekend ? mod(prev + 1, 7) : mod(prev + 1, 5)));
   };
 
   const swipedRight = () => {
-    setCurrentDay((prev) =>
-      showWeekend ? mod(prev - 1, 7) : mod(prev - 1, 5);
-    );
+    setCurrentDay((prev) => (showWeekend ? mod(prev - 1, 7) : mod(prev - 1, 5)));
   };
 
   const getTimelineStyle = () => {

--- a/static/js/redux/ui/day_calendar.tsx
+++ b/static/js/redux/ui/day_calendar.tsx
@@ -96,7 +96,7 @@ const DayCalendar = (props: DayCalendarProps) => {
     } else if (currentDay == 6 && !showWeekend) {
       setCurrentDay(0);
     }
-  }, [currentDay, showWeekend])
+  }, [currentDay, showWeekend]);
 
   const mod = (n: number, m: number) => ((n % m) + m) % m;
 

--- a/static/js/redux/ui/day_calendar.tsx
+++ b/static/js/redux/ui/day_calendar.tsx
@@ -93,7 +93,7 @@ const DayCalendar = (props: DayCalendarProps) => {
   useEffect(() => {
     if (currentDay === 5 && !showWeekend) {
       setCurrentDay(4);
-    } else if (currentDay == 6 && !showWeekend) {
+    } else if (currentDay === 6 && !showWeekend) {
       setCurrentDay(0);
     }
   }, [currentDay, showWeekend]);
@@ -101,15 +101,15 @@ const DayCalendar = (props: DayCalendarProps) => {
   const mod = (n: number, m: number) => ((n % m) + m) % m;
 
   const swipedLeft = () => {
-    setCurrentDay((prev) => {
-      return showWeekend ? mod(prev + 1, 7) : mod(prev + 1, 5);
-    });
+    setCurrentDay((prev) => 
+      showWeekend ? mod(prev + 1, 7) : mod(prev + 1, 5);
+    );
   };
 
   const swipedRight = () => {
-    setCurrentDay((prev) => {
-      return showWeekend ? mod(prev - 1, 7) : mod(prev - 1, 5);
-    });
+    setCurrentDay((prev) =>
+      showWeekend ? mod(prev - 1, 7) : mod(prev - 1, 5);
+    );
   };
 
   const getTimelineStyle = () => {

--- a/static/js/redux/ui/day_calendar.tsx
+++ b/static/js/redux/ui/day_calendar.tsx
@@ -51,7 +51,7 @@ const Row = (props: RowProps) => {
 };
 
 type DayCalendarProps = {
-  togglePreferenceModal: Function;
+  showPreferenceModal: Function;
   triggerSaveCalendarModal: Function;
   isFetchingShareLink: boolean;
   endHour: number;
@@ -206,7 +206,7 @@ const DayCalendar = (props: DayCalendarProps) => {
   );
 
   const preferenceButton = (
-    <button onClick={() => props.togglePreferenceModal()} className="save-timetable">
+    <button onClick={() => props.showPreferenceModal()} className="save-timetable">
       <i className="fa fa-cog" />
     </button>
   );

--- a/static/js/redux/ui/modals/preference_modal.tsx
+++ b/static/js/redux/ui/modals/preference_modal.tsx
@@ -20,6 +20,7 @@ import {
   preferencesActions,
   savePreferences,
 } from "../../state/slices/preferencesSlice";
+import { saveLocalPreferences } from "../../util";
 
 const PreferenceModal = () => {
   const { tryWithConflicts, showWeekend, isModalVisible } = useAppSelector(
@@ -47,10 +48,16 @@ const PreferenceModal = () => {
     width: "100%",
   };
 
+  const isLoggedIn = useAppSelector((state) => state.userInfo.data.isLoggedIn);
+
   const dispatch = useAppDispatch();
 
   const onSave = () => {
-    dispatch(savePreferences);
+    if (isLoggedIn) {
+      dispatch(savePreferences);
+    } else {
+      saveLocalPreferences({ tryWithConflicts, showWeekend });
+    }
     dispatch(preferencesActions.hidePreferenceModal());
   };
 

--- a/static/js/redux/ui/modals/preference_modal.tsx
+++ b/static/js/redux/ui/modals/preference_modal.tsx
@@ -61,6 +61,32 @@ const PreferenceModal = () => {
     dispatch(preferencesActions.hidePreferenceModal());
   };
 
+  const createPreferenceRow = (
+    label: string,
+    name: string,
+    checked: boolean,
+    onChange: () => void
+  ) => (
+    <div className="preference-row">
+      <div style={{ marginRight: "auto", marginLeft: "15%" }}>
+        <p style={{ margin: 0 }}>{label}</p>
+      </div>
+      <div style={{ marginLeft: "auto", marginRight: "10%" }}>
+        <label className="switch switch-slide" htmlFor={name}>
+          <input
+            id={name}
+            className="switch-input"
+            type="checkbox"
+            checked={checked}
+            onChange={() => onChange()}
+          />
+          <span className="switch-label" data-on="Enabled" data-off="Disabled" />
+          <span className="switch-handle" />
+        </label>
+      </div>
+    </div>
+  );
+
   return (
     <FadeModal
       ref={modal}
@@ -70,52 +96,22 @@ const PreferenceModal = () => {
     >
       <div id="perf-modal-wrapper">
         {modalHeader}
-        <div className="conflict-row">
-          <div style={{ marginRight: "auto", marginLeft: "15%" }}>
-            <p style={{ margin: 0 }}>Conflicts: </p>
-          </div>
-          <div style={{ marginLeft: "auto", marginRight: "10%" }}>
-            <label className="switch switch-slide" htmlFor="with-conflicts">
-              <input
-                id="with-conflicts"
-                className="switch-input"
-                type="checkbox"
-                checked={tryWithConflicts}
-                onChange={() => dispatch(preferencesActions.toggleConflicts())}
-              />
-              <span className="switch-label" data-on="Enabled" data-off="Disabled" />
-              <span className="switch-handle" />
-            </label>
-          </div>
-        </div>
-        <div className="conflict-row">
-          <div style={{ marginRight: "auto", marginLeft: "15%" }}>
-            <p style={{ margin: 0 }}>Show Weekends: </p>
-          </div>
-          <div style={{ marginLeft: "auto", marginRight: "10%" }}>
-            <label className="switch switch-slide" htmlFor="show-weekend">
-              <input
-                id="show-weekend"
-                className="switch-input"
-                type="checkbox"
-                checked={showWeekend}
-                onChange={() => dispatch(preferencesActions.toggleShowWeekend())}
-              />
-              <span className="switch-label" data-on="Enabled" data-off="Disabled" />
-              <span className="switch-handle" />
-            </label>
-          </div>
-        </div>
-        <hr style={{ marginTop: 0, width: "80%" }} />
-        <div className="preference-footer">
-          <button
-            className="btn btn-primary"
-            style={{ marginLeft: "auto", marginRight: "auto" }}
-            onClick={onSave}
-          >
-            Save and Close
-          </button>
-        </div>
+        {createPreferenceRow("Conflicts:", "with-conflicts", tryWithConflicts, () => {
+          dispatch(preferencesActions.toggleConflicts());
+        })}
+        {createPreferenceRow("Show Weekends:", "show-weekends", showWeekend, () => {
+          dispatch(preferencesActions.toggleShowWeekend());
+        })}
+      </div>
+      <hr style={{ marginTop: 0, width: "80%" }} />
+      <div className="preference-footer">
+        <button
+          className="btn btn-primary"
+          style={{ marginLeft: "auto", marginRight: "auto" }}
+          onClick={onSave}
+        >
+          Save and Close
+        </button>
       </div>
     </FadeModal>
   );

--- a/static/js/redux/ui/modals/preference_modal.tsx
+++ b/static/js/redux/ui/modals/preference_modal.tsx
@@ -96,9 +96,14 @@ const PreferenceModal = () => {
     >
       <div id="perf-modal-wrapper">
         {modalHeader}
-        {createPreferenceRow("Conflicts:", "with-conflicts", tryWithConflicts, () => {
-          dispatch(preferencesActions.toggleConflicts());
-        })}
+        {createPreferenceRow(
+          "Allow Conflicts:",
+          "with-conflicts",
+          tryWithConflicts,
+          () => {
+            dispatch(preferencesActions.toggleConflicts());
+          }
+        )}
         {createPreferenceRow("Show Weekends:", "show-weekends", showWeekend, () => {
           dispatch(preferencesActions.toggleShowWeekend());
         })}

--- a/static/js/redux/ui/modals/preference_modal.tsx
+++ b/static/js/redux/ui/modals/preference_modal.tsx
@@ -16,7 +16,10 @@ import React, { useEffect, useRef } from "react";
 // @ts-ignore
 import { FadeModal } from "boron-15";
 import { useAppDispatch, useAppSelector } from "../../hooks";
-import { preferencesActions } from "../../state/slices/preferencesSlice";
+import {
+  preferencesActions,
+  savePreferences,
+} from "../../state/slices/preferencesSlice";
 
 const PreferenceModal = () => {
   const { tryWithConflicts, showWeekend, isModalVisible } = useAppSelector(
@@ -101,7 +104,7 @@ const PreferenceModal = () => {
           <button
             className="btn btn-primary"
             style={{ marginLeft: "auto", marginRight: "auto" }}
-            onClick={() => modal.current.hide()}
+            onClick={onSave}
           >
             Save and Close
           </button>

--- a/static/js/redux/ui/modals/preference_modal.tsx
+++ b/static/js/redux/ui/modals/preference_modal.tsx
@@ -46,12 +46,17 @@ const PreferenceModal = () => {
 
   const dispatch = useAppDispatch();
 
+  const onSave = () => {
+    dispatch(savePreferences);
+    dispatch(preferencesActions.hidePreferenceModal());
+  };
+
   return (
     <FadeModal
       ref={modal}
       className="pref-modal max-modal"
       modalStyle={modalStyle}
-      onHide={() => dispatch(preferencesActions.togglePreferenceModal())}
+      onHide={() => dispatch(preferencesActions.hidePreferenceModal())}
     >
       <div id="perf-modal-wrapper">
         {modalHeader}

--- a/static/js/redux/ui/slot.jsx
+++ b/static/js/redux/ui/slot.jsx
@@ -324,9 +324,7 @@ class Slot extends React.Component {
     return (
       <div>
         <StyleRoot>
-          <div className="fc-event-container">
-            {slot}
-          </div>
+          <div className="fc-event-container">{slot}</div>
         </StyleRoot>
       </div>
     );

--- a/student/migrations/0043_personaltimetable_show_weekend.py
+++ b/student/migrations/0043_personaltimetable_show_weekend.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('student', '0042_student_preferred_name'),
+        ("student", "0042_student_preferred_name"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='personaltimetable',
-            name='show_weekend',
+            model_name="personaltimetable",
+            name="show_weekend",
             field=models.BooleanField(blank=True, default=True),
         ),
     ]

--- a/student/models.py
+++ b/student/models.py
@@ -164,6 +164,7 @@ class PersonalTimetable(timetable_models.Timetable):
     has_conflict = models.BooleanField(blank=True, default=False)
     show_weekend = models.BooleanField(blank=True, default=True)
 
+
 class RegistrationToken(models.Model):
     """A push notification token for Chrome notification via Google Cloud Messaging"""
 

--- a/student/tests.py
+++ b/student/tests.py
@@ -67,7 +67,10 @@ class UrlsTest(UrlTestCase):
             "/delete_account/", "helpers.mixins.FeatureFlowView"
         )
         self.assertUrlResolvesToView("/user/events/", "student.views.PersonalEventView")
-        self.assertUrlResolvesToView("/user/timetables/6/preferences/", "student.views.UserTimetablePreferenceView")
+        self.assertUrlResolvesToView(
+            "/user/timetables/6/preferences/",
+            "student.views.UserTimetablePreferenceView",
+        )
 
 
 class UserViewTest(APITestCase):
@@ -270,12 +273,9 @@ class UserTimetableViewTest(APITestCase):
             semester=self.sem,
             student=self.student,
             show_weekend=True,
-            has_conflict=True
+            has_conflict=True,
         )
-        data = {
-            "show_weekend": False,
-            "has_conflict": False
-        }
+        data = {"show_weekend": False, "has_conflict": False}
         endpoint = f"/user/timetables/{timetable.id}/preferences/"
         request = self.factory.put(endpoint, data, format="json")
         get_auth_response(request, self.user, endpoint, pk=timetable.id)

--- a/student/views.py
+++ b/student/views.py
@@ -45,7 +45,11 @@ from student.utils import (
     get_student_tts,
 )
 from timetable.models import Semester, Course, Section
-from timetable.serializers import DisplayTimetableSerializer, EventSerializer, PersonalTimeTablePreferencesSerializer
+from timetable.serializers import (
+    DisplayTimetableSerializer,
+    EventSerializer,
+    PersonalTimeTablePreferencesSerializer,
+)
 from helpers.mixins import ValidateSubdomainMixin, RedirectToSignupMixin
 from helpers.decorators import validate_subdomain
 from semesterly.settings import get_secret
@@ -332,7 +336,9 @@ class UserTimetableView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView):
         )
 
 
-class UserTimetablePreferenceView(ValidateSubdomainMixin, RedirectToSignupMixin, GenericAPIView, UpdateModelMixin):
+class UserTimetablePreferenceView(
+    ValidateSubdomainMixin, RedirectToSignupMixin, GenericAPIView, UpdateModelMixin
+):
     """
     Used to update timetable preferences
     """

--- a/timetable/utils.py
+++ b/timetable/utils.py
@@ -29,7 +29,9 @@ Timetable = namedtuple("Timetable", "courses sections has_conflict")
 class DisplayTimetable:
     """Object that represents the frontend's interpretation of a timetable."""
 
-    def __init__(self, slots, has_conflict, show_weekend, name="", events=None, id=None):
+    def __init__(
+        self, slots, has_conflict, show_weekend, name="", events=None, id=None
+    ):
         self.slots = slots
         self.has_conflict = has_conflict
         self.name = name
@@ -52,7 +54,11 @@ class DisplayTimetable:
         ]
         id = timetable.id if isinstance(timetable, PersonalTimetable) else None
         # set show_weekend to False if timetable is not a PersonalTimetable (ex: SharedTimetable)
-        show_weekend = timetable.show_weekend if isinstance(timetable, PersonalTimetable) else False
+        show_weekend = (
+            timetable.show_weekend
+            if isinstance(timetable, PersonalTimetable)
+            else False
+        )
         return DisplayTimetable(
             slots,
             timetable.has_conflict,
@@ -71,7 +77,7 @@ def courses_to_timetables(
     custom_events,
     with_conflicts,
     optional_course_ids,
-    show_weekend
+    show_weekend,
 ):
     all_offerings = courses_to_slots(
         courses, locked_sections, semester, optional_course_ids

--- a/timetable/views.py
+++ b/timetable/views.py
@@ -83,7 +83,7 @@ class TimetableView(CsrfExemptMixin, ValidateSubdomainMixin, APIView):
                 custom_events,
                 with_conflicts,
                 opt_course_ids,
-                show_weekend
+                show_weekend,
             )
         ]
 


### PR DESCRIPTION
## Description
* Connects frontend logic to backend logic for the save preferences modal
  * Receive preferences from when timetables are changed and update accordingly
  * Actually save preferences when Save is clicked in the preference modal

## Change Log
* Add `showWeekend` to `Timetable` type
* Add `getTimetablePreferencesEndpoint(id)` endpoint
* Refactor `togglePreferencesModal` into `showPreferencesModal` and `hidePreferencesModal`
* Add `savePreferences` method to `preferencesSlice`
* Add `static/bundle` to `.prettierignore`
