### PR TITLE
Add loading circle when switching semesters

### DIFF
--- a/static/js/redux/actions/user_actions.jsx
+++ b/static/js/redux/actions/user_actions.jsx
@@ -277,7 +277,6 @@ export const saveSettings = (callback) => async (dispatch, getState) => {
 };
 
 export const getUserSavedTimetables = (semester) => (dispatch, getState) => {
-  const state = getState();
   dispatch(userInfoActions.requestSaveUserInfo());
   dispatch(timetablesActions.requestTimetables());
   fetch(getLoadSavedTimetablesEndpoint(semester), {

--- a/static/js/redux/actions/user_actions.jsx
+++ b/static/js/redux/actions/user_actions.jsx
@@ -46,6 +46,7 @@ import {
   closeTermsOfServiceModal,
   triggerTermsOfServiceModal,
 } from "../state/slices/termsOfServiceModalSlice";
+import { timetablesActions } from "../state/slices/timetablesSlice";
 
 // temporary fix to allow custom event debounce
 let autoSaveTimer;
@@ -275,8 +276,10 @@ export const saveSettings = (callback) => async (dispatch, getState) => {
   }
 };
 
-export const getUserSavedTimetables = (semester) => (dispatch) => {
+export const getUserSavedTimetables = (semester) => (dispatch, getState) => {
+  const state = getState();
   dispatch(userInfoActions.requestSaveUserInfo());
+  dispatch(timetablesActions.requestTimetables());
   fetch(getLoadSavedTimetablesEndpoint(semester), {
     credentials: "include",
   })

--- a/static/js/redux/state/slices/timetablesSlice.ts
+++ b/static/js/redux/state/slices/timetablesSlice.ts
@@ -84,9 +84,6 @@ const timetablesSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder
-      .addCase(updateSemester, (state) => {
-        state.isFetching = false;
-      })
       .addCase(receiveCourses, (state) => {
         state.isFetching = false;
       })


### PR DESCRIPTION
## Description
Add loading circle to the top bar when changing semesters.
  
## Change Log
Removed updateSemester reducer from timetablesSlice in order to let loading circle spin when changing semesters.

Previously, `isFetching` was set to `true` when switching semesters, but was set back to `false` again while the async `fetch(getLoadSavedTimetablesEndpoint(semester))` call was being handled, so the spinner never got a chance to spin.