### PR TITLE
Credit Ticker: Increase ticking speed

### DIFF
--- a/static/js/redux/ui/credit_ticker.tsx
+++ b/static/js/redux/ui/credit_ticker.tsx
@@ -33,11 +33,11 @@ const CreditTicker = () => {
   useEffect(() => {
     setTimeout(() => {
       if (parseFloat(credits.toFixed(2)) > parseFloat(displayedCredits.toFixed(2))) {
-        setDisplayedCredits((previous) => previous + 0.05);
+        setDisplayedCredits((previous) => previous + 0.25);
       } else if (
         parseFloat(credits.toFixed(2)) < parseFloat(displayedCredits.toFixed(2))
       ) {
-        setDisplayedCredits((previous) => previous - 0.05);
+        setDisplayedCredits((previous) => previous - 0.25);
       }
     }, 8);
   }, [credits, displayedCredits]);


### PR DESCRIPTION
## Description
Frankly, the credit ticker goes up/down too slowly imo. Let's make it go faster.

## Change Log
Increase speed of credit ticker by 5x (0.05 inc/dec to 0.25)