### PR TITLE
Preference Modal: Hide allow conflicts

### DIFF
--- a/static/js/redux/ui/modals/preference_modal.tsx
+++ b/static/js/redux/ui/modals/preference_modal.tsx
@@ -93,14 +93,6 @@ const PreferenceModal = () => {
     >
       <div id="perf-modal-wrapper">
         {modalHeader}
-        {createPreferenceRow(
-          "Allow Conflicts:",
-          "with-conflicts",
-          tryWithConflicts,
-          () => {
-            dispatch(preferencesActions.toggleConflicts());
-          }
-        )}
         {createPreferenceRow("Show Weekends:", "show-weekends", showWeekend, () => {
           dispatch(preferencesActions.toggleShowWeekend());
         })}


### PR DESCRIPTION
## Description
Hides the option to toggle whether to allow conflicts or not. This is so that users don't toggle it off while there's an existing conflict, which would cause their timetable to get wiped on refresh. There's not much point in toggling it since an alert will appear anyways to allow it. If someone toggled it on, then they're probably not going to toggle it off.

## Change Log
Remove `Allow Conflicts:` from Preferences Modal