### PR TITLE
Fix/infinite reactions

### DIFF
--- a/student/tests.py
+++ b/student/tests.py
@@ -429,6 +429,17 @@ class ReactionTest(APITestCase):
         Reaction.objects.get(student=self.student, title=self.title)
         self.assertGreater(Course.objects.get(id=1).reaction_set.count(), 0)
 
+    def test_delete_reaction(self):
+        data = {"cid": 1, "title": self.title}
+        request = self.factory.post("/user/reactions/", data, format="json")
+        get_auth_response(request, self.user, "/user/reactions/")
+        request = self.factory.post("/user/reactions/", data, format="json")
+        response = get_auth_response(request, self.user, "/user/reactions/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue("reactions" in response.data)
+        with self.assertRaises(Reaction.DoesNotExist):
+            Reaction.objects.get(student=self.student, title=self.title)
+
 
 class PersonalEventTest(APITestCase):
     def setUp(self):

--- a/student/views.py
+++ b/student/views.py
@@ -545,7 +545,7 @@ class ReactionView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView):
         return Response(response, status=status.HTTP_200_OK)
 
     def reaction_exists(self, title, student, course):
-        course.reaction_set.filter(title=title, student=student).exists()
+        return course.reaction_set.filter(title=title, student=student).exists()
 
     def create_reaction(self, title, student, course):
         reaction = Reaction(student=student, title=title)
@@ -553,9 +553,9 @@ class ReactionView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView):
         course.reaction_set.add(reaction)
 
     def remove_reaction(self, title, student, course):
-        reaction = course.reaction_set.get(title=title, student=student)
-        course.reaction_set.remove(reaction)
-        reaction.delete()
+        reactions = course.reaction_set.filter(title=title, student=student)
+        course.reaction_set.filter(pk__in=reactions).delete()
+        reactions.delete()
 
 
 class PersonalEventView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView):


### PR DESCRIPTION
## Description
Prevents users from infinitely reacting from courses. The damage control is to delete all reactions when they react again, but if they leave it untouched, they will be allowed to have multiple reactions for that course. The alternative to migrate the db either with a SQL query or a RunPython command, which is too complex to be worth doing in my opinion, as reactions are a fairly small part of Semester.ly.

## Change Log
* Add unit test for deleting a reaction (which would have caught this bug)
* Properly check for existing reaction
* Delete all reactions upon reacting again.