### PR TITLE
Custom events: Properly delete when resetting

### DIFF
--- a/student/views.py
+++ b/student/views.py
@@ -288,9 +288,7 @@ class UserTimetableView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView):
     def update_events(self, tt, events):
         """Replace tt's events with input events. Deletes all old events to avoid
         buildup in db"""
-        to_delete = tt.events.all()
-        tt.events.clear()
-        to_delete.delete()
+        tt.events.all().delete()
         for event in events:
             credits = self.validate_credits(event)
             event_obj = PersonalEvent.objects.create(


### PR DESCRIPTION
## Description
The custom events aren't properly deleted in the backend; instead, the events' timetable_id's are nullified and are left in the db.

## Change Log
Fix events not deleting