### PR TITLE
Revert/debug mode

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,8 @@
 node_modules/
 static/js/modules/
 static/js/redux/__tests__/*/__snapshots__/
+static/bundles/
+static/admin/
+static/django_extensions/
+static/drf-yasg/
+static/rest_framework/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,7 @@
 docs
 venv
-static/bundles
+static/bundles/
+static/admin/
+static/django_extensions/
+static/drf-yasg/
+static/rest_framework/

--- a/build/local_settings.py
+++ b/build/local_settings.py
@@ -1,6 +1,6 @@
 import os
 
-DEBUG = False
+DEBUG = True
 
 TEMPLATE_DEBUG = DEBUG
 


### PR DESCRIPTION
## Description
Reverts debug mode back to true, which was changed to test static file deployment. We opted to just place the collected static files inside of `static/`

## Change Log
Set debug back to true
Ignore collected static files for linters