### PR TITLE
PersonalEvents: Add validation for time_start and time_end

### DIFF
--- a/static/js/redux/actions/timetable_actions.jsx
+++ b/static/js/redux/actions/timetable_actions.jsx
@@ -484,7 +484,7 @@ export const finalizeCustomSlot = (id) => (dispatch, getState) => {
     return;
   }
 
-  if (convertToMinutes(event.time_end) - convertToMinutes(event.time_start) < 10) {
+  if (isNewTimeLessThan10Minutes(event.time_start, event.time_end)) {
     dispatch(customEventsActions.deletePreviewEvent(id));
     return;
   }

--- a/static/js/redux/actions/timetable_actions.jsx
+++ b/static/js/redux/actions/timetable_actions.jsx
@@ -483,11 +483,18 @@ export const finalizeCustomSlot = (id) => (dispatch, getState) => {
   if (!event) {
     return;
   }
+
+  if (convertToMinutes(event.time_end) - convertToMinutes(event.time_start) < 10) {
+    dispatch(customEventsActions.deletePreviewEvent(id));
+    return;
+  }
+
   // if no timetable id, create a new timetable which will automatically save the new event
   if (!getState().savingTimetable.activeTimetable.id) {
     dispatch(fetchStateTimetables());
     return;
   }
+
   fetch(getPersonalEventEndpoint(), {
     headers: {
       "X-CSRFToken": Cookie.get("csrftoken"),

--- a/static/js/redux/state/slices/customEventsSlice.ts
+++ b/static/js/redux/state/slices/customEventsSlice.ts
@@ -37,6 +37,9 @@ const customEventsSlice = createSlice({
       const index = state.events.findIndex((event) => event.id === oldId);
       state.events[index] = { ...state.events[index], id: newId, preview: false };
     },
+    deletePreviewEvent: (state, action: PayloadAction<number>) => {
+      state.events = state.events.filter((event) => event.id !== action.payload);
+    },
     showCustomEventsModal: (state, action: PayloadAction<number>) => {
       state.selectedEventId = action.payload;
       state.isModalVisible = true;

--- a/static/js/redux/ui/slotUtils.ts
+++ b/static/js/redux/ui/slotUtils.ts
@@ -67,7 +67,6 @@ export function onCustomSlotCreateDrop(props: any, monitor: any) {
     [timeStart, timeEnd] = [timeEnd, timeStart];
   }
   props.updateCustomSlot({ time_start: timeStart, time_end: timeEnd }, id);
-  props.finalizeCustomSlot(id);
 }
 
 let lastPreview: number = null;

--- a/student/views.py
+++ b/student/views.py
@@ -319,7 +319,6 @@ class UserTimetableView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView):
     def validate_time(self, time_start: str, time_end: str):
         start_minutes = self.convert_to_minutes(time_start)
         end_minutes = self.convert_to_minutes(time_end)
-        print(end_minutes, start_minutes, end_minutes - start_minutes)
         if end_minutes - start_minutes < 10:
             raise serializers.ValidationError(
                 "Time start must come before time end by at least 10 minutes."


### PR DESCRIPTION
## Description
Adds validation for time_start and time_end so that it can't be less than 10 minutes. This mainly impacts creating a new event with 0 minutes.

## Change Log
Add reducer for removing the preview event.
Add backend validation for events being less than 10 minutes.
