### PR TITLE
Custom Events: fix event stays as preview on drag outside

### DIFF
--- a/static/js/redux/ui/calendar_cell.jsx
+++ b/static/js/redux/ui/calendar_cell.jsx
@@ -86,7 +86,6 @@ const createTarget = {
       [timeStart, timeEnd] = [timeEnd, timeStart];
     }
     props.updateCustomSlot({ time_start: timeStart, time_end: timeEnd }, id);
-    props.finalizeCustomSlot(id);
   },
   hover(props, monitor) {
     if (props.time === lastPreview) {

--- a/static/js/redux/ui/calendar_cell.jsx
+++ b/static/js/redux/ui/calendar_cell.jsx
@@ -60,6 +60,10 @@ const createSource = {
   canDrag(props) {
     return props.loggedIn && props.customEventModeOn;
   },
+  endDrag(props, monitor) {
+    const { id } = monitor.getItem();
+    props.finalizeCustomSlot(id);
+  },
 };
 
 function collectCreateBegin(connect) {


### PR DESCRIPTION
## Description
Fix the bug where event stay as preview if dragging outside of calendar
## Change Log
Add `endDrag` to `createSource` in `calendar_cell.jsx`