### PR TITLE
Saving timetables: Allow save if no slots, just as long as it's not up to date

### DIFF
--- a/static/js/redux/actions/user_actions.jsx
+++ b/static/js/redux/actions/user_actions.jsx
@@ -138,11 +138,8 @@ export const saveTimetable =
     if (!state.userInfo.data.isLoggedIn) {
       return dispatch(signupModalActions.showSignupModal());
     }
-    const activeTimetable = getActiveTimetable(state);
 
-    // if current timetable is empty or we're already in saved state, don't save this timetable
-    const numSlots = activeTimetable.slots.length + state.customEvents.events.length;
-    if (numSlots === 0 || state.savingTimetable.upToDate) {
+    if (state.savingTimetable.upToDate) {
       return null;
     }
 
@@ -308,9 +305,7 @@ export const autoSave = () => (dispatch, getState) => {
   clearTimeout(autoSaveTimer);
   autoSaveTimer = setTimeout(() => {
     const state = getState();
-    const existsSlots = getActiveTimetable(state).slots.length > 0;
-    const existsCustomEvents = state.customEvents.events.length > 0;
-    if (state.userInfo.data.isLoggedIn && (existsSlots || existsCustomEvents)) {
+    if (state.userInfo.data.isLoggedIn) {
       dispatch(saveTimetable(true));
       clearLocalTimetable();
     }


### PR DESCRIPTION
## Description
Fixes bug that doesn't let you remove last course

## Change Log
Remove existing validation that checks if you have no slots before saving. Since it's possible that you can delete the last course, you'll end up with no slots, but it's a valid change, so it should save.