### PR TITLE
Compare timetables/sidebar slots

### DIFF
--- a/static/css/timetable/framework/page_layout.scss
+++ b/static/css/timetable/framework/page_layout.scss
@@ -33,7 +33,7 @@ textarea {
   height: 100%;
 }
 
-.side-bar {
+@mixin side-bar {
   background-color: $gfff;
   bottom: auto;
   height: 100%;
@@ -56,7 +56,17 @@ textarea {
   }
 }
 
-.main-bar {
+.side-bar {
+  @include side-bar;
+}
+
+.side-bar-compare-timetable {
+  @include side-bar;
+  left: calc(100% - 600px);
+  width: 600px;
+}
+
+@mixin main-bar {
   float: left;
   height: 100%;
   opacity: 1;
@@ -72,6 +82,18 @@ textarea {
 
   &.less-cal {
     width: calc(100% - 300px);
+  }
+}
+
+.main-bar {
+  @include main-bar;
+}
+
+.main-bar-compare-timetable {
+  @include main-bar;
+  width: calc(100% - 600px);
+  &.less-cal {
+    width: calc(100% - 600px);
   }
 }
 
@@ -111,7 +133,7 @@ textarea {
     display: inline-block;
     font-size: 20px;
     line-height: 30px;
-    vertical-align:	middle;
+    vertical-align: middle;
   }
 
   span {
@@ -122,7 +144,7 @@ textarea {
     margin-left: 4px;
     padding: 3px 0;
     text-align: left;
-    vertical-align:	middle;
+    vertical-align: middle;
     width: 60px;
   }
 }
@@ -162,7 +184,6 @@ textarea {
     }
   }
 }
-
 
 @media (max-width: 766px) {
   .main-bar {
@@ -272,7 +293,6 @@ textarea {
 }
 // End Navicon
 
-
 li {
   &.footer-button {
     line-height: 22px;
@@ -345,7 +365,7 @@ footer {
   margin: 5px 0;
 }
 
-@media(max-width: 710px) {
+@media (max-width: 710px) {
   .data-last-updated {
     float: none;
     text-align: center;

--- a/static/css/timetable/main.scss
+++ b/static/css/timetable/main.scss
@@ -22,6 +22,7 @@
 @import "modules/tooltip";
 
 // Partials
+@import "partials/compare_timetable_sidebar.scss";
 @import "partials/course_modal";
 @import "partials/custom_event_modal.scss";
 @import "partials/day_calendar";

--- a/static/css/timetable/partials/compare_timetable_sidebar.scss
+++ b/static/css/timetable/partials/compare_timetable_sidebar.scss
@@ -1,0 +1,12 @@
+.slots-comparison {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.slots-list {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}

--- a/static/css/timetable/partials/compare_timetable_sidebar.scss
+++ b/static/css/timetable/partials/compare_timetable_sidebar.scss
@@ -1,3 +1,19 @@
+@import "../framework/page_layout.scss";
+
+.side-bar-compare-timetable {
+  @include side-bar;
+  left: calc(100% - 600px);
+  width: 600px;
+}
+
+.main-bar-compare-timetable {
+  @include main-bar;
+  width: calc(100% - 600px);
+  &.less-cal {
+    width: calc(100% - 600px);
+  }
+}
+
 .slots-comparison {
   display: flex;
   flex-direction: row;

--- a/static/js/redux/state/slices/compareTimetableSlice.ts
+++ b/static/js/redux/state/slices/compareTimetableSlice.ts
@@ -1,19 +1,32 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { Timetable } from "../../constants/commonTypes";
 
 interface CompareTimetableSliceState {
   showCompareTimetableSideBar: boolean;
+  activeTimetable: Timetable | null;
+  comparedTimetable: Timetable | null;
 }
 
 const initialState: CompareTimetableSliceState = {
   showCompareTimetableSideBar: false,
+  activeTimetable: null,
+  comparedTimetable: null,
 };
 
 const compareTimetableSlice = createSlice({
   name: "compareTimetable",
   initialState,
   reducers: {
-    toggleCompareTimetableSideBar: (state) => {
+    toggleCompareTimetableSideBar: (
+      state,
+      action: PayloadAction<{
+        activeTimetable: Timetable;
+        comparedTimetable: Timetable;
+      }>
+    ) => {
       state.showCompareTimetableSideBar = !state.showCompareTimetableSideBar;
+      state.activeTimetable = action.payload.activeTimetable;
+      state.comparedTimetable = action.payload.comparedTimetable;
     },
   },
 });

--- a/static/js/redux/state/slices/compareTimetableSlice.ts
+++ b/static/js/redux/state/slices/compareTimetableSlice.ts
@@ -2,13 +2,13 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { Timetable } from "../../constants/commonTypes";
 
 interface CompareTimetableSliceState {
-  showCompareTimetableSideBar: boolean;
+  isComparing: boolean;
   activeTimetable: Timetable | null;
   comparedTimetable: Timetable | null;
 }
 
 const initialState: CompareTimetableSliceState = {
-  showCompareTimetableSideBar: false,
+  isComparing: false,
   activeTimetable: null,
   comparedTimetable: null,
 };
@@ -24,7 +24,7 @@ const compareTimetableSlice = createSlice({
         comparedTimetable: Timetable;
       }>
     ) => {
-      state.showCompareTimetableSideBar = !state.showCompareTimetableSideBar;
+      state.isComparing = !state.isComparing;
       state.activeTimetable = action.payload.activeTimetable;
       state.comparedTimetable = action.payload.comparedTimetable;
     },

--- a/static/js/redux/state/slices/compareTimetableSlice.ts
+++ b/static/js/redux/state/slices/compareTimetableSlice.ts
@@ -17,19 +17,25 @@ const compareTimetableSlice = createSlice({
   name: "compareTimetable",
   initialState,
   reducers: {
-    toggleCompareTimetableSideBar: (
+    startComparingTimetables: (
       state,
       action: PayloadAction<{
         activeTimetable: Timetable;
         comparedTimetable: Timetable;
       }>
     ) => {
-      state.isComparing = !state.isComparing;
+      state.isComparing = true;
       state.activeTimetable = action.payload.activeTimetable;
       state.comparedTimetable = action.payload.comparedTimetable;
+    },
+    stopComparingTimetables: (state) => {
+      state.isComparing = false;
+      state.activeTimetable = null;
+      state.comparedTimetable = null;
     },
   },
 });
 
-export const { toggleCompareTimetableSideBar } = compareTimetableSlice.actions;
+export const { startComparingTimetables, stopComparingTimetables } =
+  compareTimetableSlice.actions;
 export default compareTimetableSlice.reducer;

--- a/static/js/redux/ui/Calendar.tsx
+++ b/static/js/redux/ui/Calendar.tsx
@@ -325,6 +325,23 @@ const Calendar = (props: CalendarProps) => {
     </div>
   );
 
+  const isComparingTimetables = useAppSelector(
+    (state) => state.compareTimetable.isComparing
+  );
+  const toolbar = isComparingTimetables ? (
+    <>{preferenceButton}</>
+  ) : (
+    <>
+      {addSISButton}
+      {toggleCustomEventModeButton}
+      {shareButton}
+      {shareLink}
+      {addNewTimetableButton}
+      {saveToCalendarButton}
+      {preferenceButton}
+    </>
+  );
+
   const showWeekend = useAppSelector((state) => state.preferences.showWeekend);
 
   return (
@@ -338,15 +355,7 @@ const Calendar = (props: CalendarProps) => {
           {!customEventModeOn ? <PaginationContainer /> : null}
           {customEventDescription}
         </div>
-        <div className="fc-right">
-          {addSISButton}
-          {toggleCustomEventModeButton}
-          {shareButton}
-          {shareLink}
-          {addNewTimetableButton}
-          {saveToCalendarButton}
-          {preferenceButton}
-        </div>
+        <div className="fc-right">{toolbar}</div>
         <div className="fc-center" />
         <div className="fc-clear" />
       </div>

--- a/static/js/redux/ui/CompareTimetableSidebar.tsx
+++ b/static/js/redux/ui/CompareTimetableSidebar.tsx
@@ -5,7 +5,7 @@ import { DenormalizedCourse } from "../constants/commonTypes";
 import { getCourseShareLink } from "../constants/endpoints";
 import { useAppSelector } from "../hooks";
 import { getCoursesFromSlots, getCurrentSemester } from "../state";
-import { toggleCompareTimetableSideBar } from "../state/slices/compareTimetableSlice";
+import { stopComparingTimetables } from "../state/slices/compareTimetableSlice";
 import MasterSlot from "./MasterSlot";
 
 const CompareTimetableSideBar = () => {
@@ -49,7 +49,7 @@ const CompareTimetableSideBar = () => {
         <div className="slots-list">{comparedSlots}</div>
       </div>
       <div
-        onClick={() => dispatch(toggleCompareTimetableSideBar())}
+        onClick={() => dispatch(stopComparingTimetables())}
         style={{ cursor: "pointer" }}
       >
         Exit Compare Timetables

--- a/static/js/redux/ui/CompareTimetableSidebar.tsx
+++ b/static/js/redux/ui/CompareTimetableSidebar.tsx
@@ -42,7 +42,7 @@ const CompareTimetableSideBar = () => {
   const comparedSlots = comparedCourses.map((course) => createMasterSlot(course, 1));
 
   return (
-    <div>
+    <div className="side-bar-compare-timetable">
       <p>New sidebar</p>
       <div className="slots-comparison">
         <div className="slots-list">{activeSlots}</div>

--- a/static/js/redux/ui/CompareTimetableSidebar.tsx
+++ b/static/js/redux/ui/CompareTimetableSidebar.tsx
@@ -5,9 +5,15 @@ import { toggleCompareTimetableSideBar } from "../state/slices/compareTimetableS
 
 const CompareTimetableSideBar = () => {
   const dispatch = useDispatch();
-  const isCompareTimetableSideBarVisible = useAppSelector(
-    (state) => state.compareTimetable.showCompareTimetableSideBar
+  const activeTimetable = useAppSelector(
+    (state) => state.compareTimetable.activeTimetable
   );
+  const comparedTimetable = useAppSelector(
+    (state) => state.compareTimetable.comparedTimetable
+  );
+
+  console.log("Active: ", activeTimetable);
+  console.log("Compared: ", comparedTimetable);
 
   return (
     <div>

--- a/static/js/redux/ui/CreditTicker.tsx
+++ b/static/js/redux/ui/CreditTicker.tsx
@@ -31,7 +31,7 @@ const CreditTicker = () => {
     events.reduce((acc: number, event: Event) => acc + parseFloat(event.credits), 0);
 
   useEffect(() => {
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       if (parseFloat(credits.toFixed(2)) > parseFloat(displayedCredits.toFixed(2))) {
         setDisplayedCredits((previous) => previous + 0.25);
       } else if (
@@ -40,6 +40,7 @@ const CreditTicker = () => {
         setDisplayedCredits((previous) => previous - 0.25);
       }
     }, 8);
+    return () => clearTimeout(timer);
   }, [credits, displayedCredits]);
 
   return (

--- a/static/js/redux/ui/DayCalendar.tsx
+++ b/static/js/redux/ui/DayCalendar.tsx
@@ -228,20 +228,30 @@ const DayCalendar = (props: DayCalendarProps) => {
       <img alt="add" src="static/img/addtocalendar.png" />
     </button>
   );
+
+  const isComparingTimetables = useAppSelector(
+    (state) => state.compareTimetable.isComparing
+  );
+  const toolbar = isComparingTimetables ? (
+    <>{preferenceButton}</>
+  ) : (
+    <>
+      {shareButton}
+      {shareLink}
+      {addButton}
+      {saveButton}
+      {preferenceButton}
+      {saveToCalendarButton}
+    </>
+  );
+
   return (
     <div className="calendar fc fc-ltr fc-unthemed day-calendar">
       <div className="fc-toolbar no-print">
         <div className="fc-left">
           <PaginationContainer />
         </div>
-        <div className="fc-right">
-          {shareButton}
-          {shareLink}
-          {addButton}
-          {saveButton}
-          {preferenceButton}
-          {saveToCalendarButton}
-        </div>
+        <div className="fc-right">{toolbar}</div>
         <div className="fc-center" />
         <div className="fc-clear cf">
           <div className="day-pills">

--- a/static/js/redux/ui/MasterSlot.tsx
+++ b/static/js/redux/ui/MasterSlot.tsx
@@ -20,13 +20,13 @@ import uniq from "lodash/uniq";
 import Clipboard from "clipboard";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import COLOUR_DATA from "../constants/colours";
-import { Classmate, Course } from "../constants/commonTypes";
+import { Classmate, DenormalizedCourse } from "../constants/commonTypes";
 
 type MasterSlotProps = {
   colourIndex: number;
   inModal?: boolean;
   fakeFriends: number;
-  course: Course;
+  course: DenormalizedCourse;
   professors: string[];
   classmates: {
     current: Classmate[];

--- a/static/js/redux/ui/Semesterly.tsx
+++ b/static/js/redux/ui/Semesterly.tsx
@@ -183,6 +183,10 @@ const Semesterly = () => {
       <CalendarContainer />
     );
 
+  const mainbarClassName = `main-bar${
+    isComparingTimetables ? "-compare-timetable" : ""
+  }`;
+
   return (
     <div className="page-wrapper">
       <TopBarContainer />
@@ -201,7 +205,7 @@ const Semesterly = () => {
       <TermsOfServiceBannerContainer />
       <AlertBox ref={alertBoxRef} />
       <div className="all-cols">
-        <div className="main-bar">
+        <div className={mainbarClassName}>
           {cal}
           <footer className="footer navbar no-print">
             <p className="data-last-updated no-print">

--- a/static/js/redux/ui/Semesterly.tsx
+++ b/static/js/redux/ui/Semesterly.tsx
@@ -77,8 +77,8 @@ const Semesterly = () => {
     (state) => state.alerts.alertTimetableExists
   );
 
-  const isCompareTimetableSideBarVisible = useAppSelector(
-    (state) => state.compareTimetable.showCompareTimetableSideBar
+  const isComparingTimetables = useAppSelector(
+    (state) => state.compareTimetable.isComparing
   );
 
   const mql = window.matchMedia("(orientation: portrait)");
@@ -280,7 +280,7 @@ const Semesterly = () => {
             </ul>
           </footer>
         </div>
-        {isCompareTimetableSideBarVisible ? <CompareTimetableSideBar /> : <SideBar />}
+        {isComparingTimetables ? <CompareTimetableSideBar /> : <SideBar />}
       </div>
     </div>
   );

--- a/static/js/redux/ui/SideBar.tsx
+++ b/static/js/redux/ui/SideBar.tsx
@@ -146,7 +146,7 @@ const SideBar = () => {
             colourIndex={colourIndex}
             classmates={courseToClassmates[course.id]}
             onTimetable={isCourseInRoster(course.id)}
-            course={course as any}
+            course={course}
             fetchCourseInfo={() => dispatch(fetchCourseInfo(course.id))}
             removeCourse={() => dispatch(addOrRemoveCourse(course.id))}
             getShareLink={getShareLink}
@@ -166,7 +166,7 @@ const SideBar = () => {
             onTimetable={isCourseInRoster(course.id)}
             colourIndex={colourIndex}
             classmates={courseToClassmates[course.id]}
-            course={course as any}
+            course={course}
             fetchCourseInfo={() => dispatch(fetchCourseInfo(course.id))}
             removeCourse={() => dispatch(addOrRemoveOptionalCourse(course))}
             getShareLink={getShareLink}

--- a/static/js/redux/ui/SideBar.tsx
+++ b/static/js/redux/ui/SideBar.tsx
@@ -65,8 +65,8 @@ const SideBar = () => {
     (state) => state.classmates.courseToClassmates
   );
   const avgRating = useAppSelector((state) => timetable.avg_rating);
-  const currentTimetableName = useAppSelector(
-    (state) => state.savingTimetable.activeTimetable.name
+  const activeTimetable = useAppSelector(
+    (state) => state.savingTimetable.activeTimetable
   );
 
   const isCourseInRoster = (courseId: number) =>
@@ -112,10 +112,15 @@ const SideBar = () => {
           >
             <i className="fa fa-clone" />
           </button>
-          {currentTimetableName !== t.name && (
+          {activeTimetable.name !== t.name && (
             <button
               onClick={(event) => {
-                dispatch(toggleCompareTimetableSideBar());
+                dispatch(
+                  toggleCompareTimetableSideBar({
+                    activeTimetable,
+                    comparedTimetable: t,
+                  })
+                );
                 event.stopPropagation();
               }}
               className="row-button"

--- a/static/js/redux/ui/SideBar.tsx
+++ b/static/js/redux/ui/SideBar.tsx
@@ -38,7 +38,7 @@ import {
 } from "../actions";
 import { togglePeerModal } from "../state/slices/peerModalSlice";
 import { Timetable } from "../constants/commonTypes";
-import { toggleCompareTimetableSideBar } from "../state/slices/compareTimetableSlice";
+import { startComparingTimetables } from "../state/slices/compareTimetableSlice";
 
 const SideBar = () => {
   const dispatch = useAppDispatch();
@@ -116,7 +116,7 @@ const SideBar = () => {
             <button
               onClick={(event) => {
                 dispatch(
-                  toggleCompareTimetableSideBar({
+                  startComparingTimetables({
                     activeTimetable,
                     comparedTimetable: t,
                   })

--- a/static/js/redux/ui/SlotManager.tsx
+++ b/static/js/redux/ui/SlotManager.tsx
@@ -152,9 +152,12 @@ const SlotManager = (props: { days: string[] }) => {
   const comparedSlots = useAppSelector(
     (state) =>
       isComparingTimetables &&
-      uniqBy(getDenormTimetable(state, state.compareTimetable.activeTimetable).slots.concat(
-        getDenormTimetable(state, state.compareTimetable.comparedTimetable).slots
-      ), (slot) => slot.section.id)
+      uniqBy(
+        getDenormTimetable(state, state.compareTimetable.activeTimetable).slots.concat(
+          getDenormTimetable(state, state.compareTimetable.comparedTimetable).slots
+        ),
+        (slot) => slot.section.id
+      )
   );
   const slots = isComparingTimetables ? comparedSlots : timetableSlots;
 
@@ -178,7 +181,7 @@ const SlotManager = (props: { days: string[] }) => {
       offerings
         .filter((offering) => offering.day in slotsByDay)
         .forEach((offering) => {
-          const colourId = isComparingTimetables ? 0: courseToColourIndex[course.id];
+          const colourId = isComparingTimetables ? 0 : courseToColourIndex[course.id];
           slotsByDay[offering.day].push(
             slotToDisplayOffering(course, section, offering, colourId)
           );

--- a/static/js/redux/ui/SlotManager.tsx
+++ b/static/js/redux/ui/SlotManager.tsx
@@ -24,7 +24,11 @@ import { getNextAvailableColour, slotToDisplayOffering } from "../util";
 import { convertToMinutes } from "./slotUtils";
 import { HoveredSlot } from "../constants/commonTypes";
 import { useAppDispatch, useAppSelector } from "../hooks";
-import { getActiveDenormTimetable, getHoveredSlots } from "../state";
+import {
+  getActiveDenormTimetable,
+  getDenormTimetable,
+  getHoveredSlots,
+} from "../state";
 import { getSchoolSpecificInfo } from "../constants/schools";
 import { getDenormCourseById } from "../state/slices/entitiesSlice";
 import {
@@ -35,6 +39,7 @@ import {
   finalizeCustomSlot,
 } from "../actions/timetable_actions";
 import { fetchCourseInfo } from "../actions/modal_actions";
+import { uniqBy } from "lodash";
 
 function getConflictStyles(slotsByDay: any) {
   const styledSlotsByDay = slotsByDay;
@@ -133,13 +138,26 @@ function getConflictStyles(slotsByDay: any) {
 const SlotManager = (props: { days: string[] }) => {
   const hoveredSlot: HoveredSlot = useAppSelector((state) => getHoveredSlots(state));
   // don't show slot if an alternative is being hovered
-  const slots = useAppSelector((state) =>
+  const timetableSlots = useAppSelector((state) =>
     getActiveDenormTimetable(state).slots.filter(
       (slot) =>
         hoveredSlot?.course.id !== slot.course.id ||
         hoveredSlot?.section.section_type !== slot.section.section_type
     )
   );
+
+  const isComparingTimetables = useAppSelector(
+    (state) => state.compareTimetable.isComparing
+  );
+  const comparedSlots = useAppSelector(
+    (state) =>
+      isComparingTimetables &&
+      uniqBy(getDenormTimetable(state, state.compareTimetable.activeTimetable).slots.concat(
+        getDenormTimetable(state, state.compareTimetable.comparedTimetable).slots
+      ), (slot) => slot.section.id)
+  );
+  const slots = isComparingTimetables ? comparedSlots : timetableSlots;
+
   const courseToColourIndex = useAppSelector((state) => state.ui.courseToColourIndex);
   const customEvents = useAppSelector((state) => state.customEvents.events);
 
@@ -160,7 +178,7 @@ const SlotManager = (props: { days: string[] }) => {
       offerings
         .filter((offering) => offering.day in slotsByDay)
         .forEach((offering) => {
-          const colourId = courseToColourIndex[course.id];
+          const colourId = isComparingTimetables ? 0: courseToColourIndex[course.id];
           slotsByDay[offering.day].push(
             slotToDisplayOffering(course, section, offering, colourId)
           );


### PR DESCRIPTION
## Description
Attempts to render the data of the active and compared timetables

Some hacks were used to get around the coloring issue @alexcjwei. I can't explain it well, but colors are pretty coupled into implementation.

## Change Log
* Add `active` and `compared` timetables to the compareTimetableState
* Show appropriate courses in `SlotManager`
* Hide most toolbar options when comparing
* Fix credit ticker memory leak
* Double size of compare timetable sidebar