### PR TITLE
Compare timetables: timetable colors

### DIFF
--- a/static/js/redux/ui/CompareTimetableSidebar.tsx
+++ b/static/js/redux/ui/CompareTimetableSidebar.tsx
@@ -7,6 +7,7 @@ import { useAppSelector } from "../hooks";
 import { getCoursesFromSlots, getCurrentSemester } from "../state";
 import { stopComparingTimetables } from "../state/slices/compareTimetableSlice";
 import MasterSlot from "./MasterSlot";
+import { isOfferingInTimetable } from "./slotUtils";
 
 const CompareTimetableSideBar = () => {
   const dispatch = useDispatch();
@@ -42,16 +43,6 @@ const CompareTimetableSideBar = () => {
         hideCloseButton
       />
     );
-  };
-
-  const isOfferingInTimetable = (timetable: Timetable, offeringId: number) => {
-    let inTimetable = false;
-    timetable.slots.forEach((currentSlot) => {
-      if (currentSlot.offerings.indexOf(offeringId) !== -1) {
-        inTimetable = true;
-      }
-    });
-    return inTimetable;
   };
 
   /**

--- a/static/js/redux/ui/CompareTimetableSidebar.tsx
+++ b/static/js/redux/ui/CompareTimetableSidebar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useDispatch } from "react-redux";
 import { fetchCourseInfo } from "../actions";
-import { DenormalizedCourse } from "../constants/commonTypes";
+import { DenormalizedCourse, Timetable } from "../constants/commonTypes";
 import { getCourseShareLink } from "../constants/endpoints";
 import { useAppSelector } from "../hooks";
 import { getCoursesFromSlots, getCurrentSemester } from "../state";
@@ -15,6 +15,12 @@ const CompareTimetableSideBar = () => {
   );
   const comparedCourses = useAppSelector((state) =>
     getCoursesFromSlots(state, state.compareTimetable.comparedTimetable.slots)
+  );
+  const activeTimetable = useAppSelector(
+    (state) => state.compareTimetable.activeTimetable
+  );
+  const comparedTimetable = useAppSelector(
+    (state) => state.compareTimetable.comparedTimetable
   );
 
   const courseToClassmates = useAppSelector(
@@ -38,8 +44,42 @@ const CompareTimetableSideBar = () => {
     );
   };
 
-  const activeSlots = activeCourses.map((course) => createMasterSlot(course, 0));
-  const comparedSlots = comparedCourses.map((course) => createMasterSlot(course, 1));
+  const isOfferingInTimetable = (timetable: Timetable, offeringId: number) => {
+    let inTimetable = false;
+    timetable.slots.forEach((currentSlot) => {
+      if (currentSlot.offerings.indexOf(offeringId) !== -1) {
+        inTimetable = true;
+      }
+    });
+    return inTimetable;
+  };
+
+  /**
+   * returns an array of course ids of the courses that have the same section in both timetables
+   */
+  const getSectionsInBothTimetables = () => {
+    const courseIds: number[] = [];
+
+    activeTimetable.slots.forEach((slot) => {
+      slot.offerings.forEach((offeringId) => {
+        if (isOfferingInTimetable(comparedTimetable, offeringId)) {
+          courseIds.push(slot.course);
+        }
+      });
+    });
+    return courseIds;
+  };
+  const sectionsInBoth = getSectionsInBothTimetables();
+
+  const activeSlots = activeCourses.map((course) => {
+    const colorIndex = sectionsInBoth.indexOf(course.id) === -1 ? 0 : 2;
+
+    return createMasterSlot(course, colorIndex);
+  });
+  const comparedSlots = comparedCourses.map((course) => {
+    const colorIndex = sectionsInBoth.indexOf(course.id) === -1 ? 1 : 2;
+    return createMasterSlot(course, colorIndex);
+  });
 
   return (
     <div className="side-bar-compare-timetable">

--- a/static/js/redux/ui/MasterSlot.tsx
+++ b/static/js/redux/ui/MasterSlot.tsx
@@ -48,7 +48,7 @@ const MasterSlot = (props: MasterSlotProps) => {
       return;
     }
     // update sibling slot colours (i.e. the slots for the same course)
-    $(`.slot-${props.course.id}`).css("background-color", colour);
+    $(`.slot-${props.course.id}-${props.colourIndex}`).css("background-color", colour);
   };
 
   const onMasterSlotHover = () => {
@@ -108,7 +108,7 @@ const MasterSlot = (props: MasterSlotProps) => {
       </div>,
     ].concat(friendCircles.slice(0, 3));
   }
-  let masterSlotClass = `master-slot slot-${props.course.id}`;
+  let masterSlotClass = `master-slot slot-${props.course.id}-${props.colourIndex}`;
   const validProfs = props.professors ? uniq(props.professors.filter((p) => p)) : false;
   const prof =
     !validProfs || validProfs.length === 0 || validProfs[0] === ""

--- a/static/js/redux/ui/Slot.tsx
+++ b/static/js/redux/ui/Slot.tsx
@@ -136,7 +136,7 @@ const Slot = (props: SlotProps) => {
 
   const updateColours = (colour: string) => {
     // update sibling slot colours (i.e. the slots for the same course)
-    $(`.slot-${props.courseId}`).css("background-color", colour);
+    $(`.slot-${props.courseId}-${props.colourId}`).css("background-color", colour);
   };
 
   const removeButton = hovered ? (
@@ -205,7 +205,7 @@ const Slot = (props: SlotProps) => {
   const slot = props.connectCreateTarget(
     props.connectDragTarget(
       <div
-        className={`fc-time-grid-event fc-event slot slot-${props.courseId}`}
+        className={`fc-time-grid-event fc-event slot slot-${props.courseId}-${props.colourId}`}
         style={getSlotStyles()}
         onClick={() => {
           props.fetchCourseInfo();

--- a/static/js/redux/ui/SlotManager.tsx
+++ b/static/js/redux/ui/SlotManager.tsx
@@ -22,7 +22,7 @@ import Slot from "./Slot";
 import CustomSlot from "./CustomSlot";
 import { getNextAvailableColour, slotToDisplayOffering } from "../util";
 import { convertToMinutes } from "./slotUtils";
-import { HoveredSlot } from "../constants/commonTypes";
+import { HoveredSlot, Offering, Timetable } from "../constants/commonTypes";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import {
   getActiveDenormTimetable,
@@ -163,6 +163,41 @@ const SlotManager = (props: { days: string[] }) => {
 
   const courseToColourIndex = useAppSelector((state) => state.ui.courseToColourIndex);
   const customEvents = useAppSelector((state) => state.customEvents.events);
+  const activeTimetable = useAppSelector(
+    (state) => state.compareTimetable.activeTimetable
+  );
+  const comparedTimetable = useAppSelector(
+    (state) => state.compareTimetable.comparedTimetable
+  );
+
+  const isOfferingInTimetable = (timetable: Timetable, offering: Offering) => {
+    let inTimetable = false;
+    timetable.slots.forEach((currentSlot) => {
+      if (currentSlot.offerings.indexOf(offering.id) !== -1) {
+        inTimetable = true;
+      }
+    });
+    return inTimetable;
+  };
+
+  const getComparedTimetableSlotColor = (offering: Offering, courseId: number) => {
+    const isOfferingInActiveTimetable = isOfferingInTimetable(
+      activeTimetable,
+      offering
+    );
+    const isOfferingInComparedTimetable = isOfferingInTimetable(
+      comparedTimetable,
+      offering
+    );
+    if (isOfferingInActiveTimetable && isOfferingInComparedTimetable) {
+      // return courseToColourIndex[courseId];
+      return 2;
+    } else if (isOfferingInActiveTimetable) {
+      return 0;
+    } else {
+      return 1;
+    }
+  };
 
   const getSlotsByDay = () => {
     const slotsByDay: any = {
@@ -181,7 +216,10 @@ const SlotManager = (props: { days: string[] }) => {
       offerings
         .filter((offering) => offering.day in slotsByDay)
         .forEach((offering) => {
-          const colourId = isComparingTimetables ? 0 : courseToColourIndex[course.id];
+          const colourId = isComparingTimetables
+            ? getComparedTimetableSlotColor(offering, course.id)
+            : courseToColourIndex[course.id];
+
           slotsByDay[offering.day].push(
             slotToDisplayOffering(course, section, offering, colourId)
           );

--- a/static/js/redux/ui/SlotManager.tsx
+++ b/static/js/redux/ui/SlotManager.tsx
@@ -21,7 +21,7 @@ import {
 import Slot from "./Slot";
 import CustomSlot from "./CustomSlot";
 import { getNextAvailableColour, slotToDisplayOffering } from "../util";
-import { convertToMinutes } from "./slotUtils";
+import { convertToMinutes, isOfferingInTimetable } from "./slotUtils";
 import { HoveredSlot, Offering, Timetable } from "../constants/commonTypes";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import {
@@ -170,24 +170,14 @@ const SlotManager = (props: { days: string[] }) => {
     (state) => state.compareTimetable.comparedTimetable
   );
 
-  const isOfferingInTimetable = (timetable: Timetable, offering: Offering) => {
-    let inTimetable = false;
-    timetable.slots.forEach((currentSlot) => {
-      if (currentSlot.offerings.indexOf(offering.id) !== -1) {
-        inTimetable = true;
-      }
-    });
-    return inTimetable;
-  };
-
   const getComparedTimetableSlotColor = (offering: Offering, courseId: number) => {
     const isOfferingInActiveTimetable = isOfferingInTimetable(
       activeTimetable,
-      offering
+      offering.id
     );
     const isOfferingInComparedTimetable = isOfferingInTimetable(
       comparedTimetable,
-      offering
+      offering.id
     );
     if (isOfferingInActiveTimetable && isOfferingInComparedTimetable) {
       // return courseToColourIndex[courseId];

--- a/static/js/redux/ui/slotUtils.ts
+++ b/static/js/redux/ui/slotUtils.ts
@@ -1,3 +1,4 @@
+import { Timetable } from "../constants/commonTypes";
 import { HALF_HOUR_HEIGHT } from "../constants/constants";
 
 export function convertToHalfHours(time: string) {
@@ -91,3 +92,13 @@ export function canDropCustomSlot(props: any, monitor: any) {
   const { day } = monitor.getItem();
   return day === props.day;
 }
+
+export const isOfferingInTimetable = (timetable: Timetable, offeringId: number) => {
+  let inTimetable = false;
+  timetable.slots.forEach((currentSlot) => {
+    if (currentSlot.offerings.indexOf(offeringId) !== -1) {
+      inTimetable = true;
+    }
+  });
+  return inTimetable;
+};


### PR DESCRIPTION
## Description
Work on rendering the slot colors of compare timetables.
![image](https://user-images.githubusercontent.com/37493948/163510280-50714a38-0a11-4104-bce9-31b993e921d0.png)

Currently:
* sections in both timetables: turquoise
* sections in active timetable: red
* sections in compared timetable: blue
## Change Log
