### PR TITLE
Fix: News Modal Padding

### DIFF
--- a/static/css/timetable/partials/news_modal.scss
+++ b/static/css/timetable/partials/news_modal.scss
@@ -11,11 +11,11 @@
   }
 
   .news-body {
-    padding: 0 2em 1em 2em;
+    padding: 1em 2em;
 
     h1 {
       font-size: 2em;
-      margin: 0.5em 0 0.5em 0;
+      margin: 0 0 0.5em 0;
       font-weight: bold;
     }
 


### PR DESCRIPTION
Adds a little space so it's not too crunched at the top if you don't use Heading 1 to start with.
Ignore the backend linter failure, that will be fixed soon.