### PR TITLE
Fix/compare timetable css consistency

### DIFF
--- a/static/css/timetable/partials/compare_timetable_sidebar.scss
+++ b/static/css/timetable/partials/compare_timetable_sidebar.scss
@@ -41,11 +41,11 @@
 
 .slots-separator {
   border-left: 2px solid rgba(196, 196, 196, 1);
-  height: 80%;
   position: absolute;
   left: 50%;
   margin-left: -5px;
-  top: 70px;
+  height: 80%;
+  top: 20px;
   z-index: -1;
 }
 

--- a/static/css/timetable/partials/compare_timetable_sidebar.scss
+++ b/static/css/timetable/partials/compare_timetable_sidebar.scss
@@ -52,7 +52,8 @@
 .compare-timetable-exit {
   position: absolute;
   right: 0;
-  padding: 0.5rem;
+  padding: 1rem;
+  margin-right: 10px;
   cursor: pointer;
 }
 

--- a/static/css/timetable/partials/compare_timetable_sidebar.scss
+++ b/static/css/timetable/partials/compare_timetable_sidebar.scss
@@ -66,8 +66,8 @@
 
 .title-wrapper {
   width: 50%;
-  margin-left: 10px;
-  margin-right: 10px;
+  margin-left: 20px;
+  margin-right: 20px;
 }
 
 .slots-wrapper {

--- a/static/css/timetable/partials/side_bar.scss
+++ b/static/css/timetable/partials/side_bar.scss
@@ -185,8 +185,9 @@
   }
 
   .sub-rating-wrapper {
-    margin-left: 50%;
-    transform: translateX(-50%);
+    display: flex;
+    margin-left: auto;
+    margin-right: auto;
   }
 }
 

--- a/static/js/redux/ui/CompareTimetableSidebar.tsx
+++ b/static/js/redux/ui/CompareTimetableSidebar.tsx
@@ -101,24 +101,20 @@ const CompareTimetableSideBar = () => {
         <div className="title-wrapper">{comparedTimetable.name}</div>
       </div>
       <div className="slots-rating">
-        <div className="col-1-3 text-center">
+        <div className="text-center">
           <CreditTicker
             timetableCourses={activeCourses}
             events={activeTimetable.events}
           />
         </div>
-        <div className="col-2-3">
-          <AvgCourseRating avgRating={activeTimetable.avg_rating} />
-        </div>
-        <div className="col-1-3 text-center">
+        <AvgCourseRating avgRating={activeTimetable.avg_rating} />
+        <div className="text-center">
           <CreditTicker
             timetableCourses={comparedCourses}
             events={comparedTimetable.events}
           />
         </div>
-        <div className="col-2-3">
-          <AvgCourseRating avgRating={comparedTimetable.avg_rating} />
-        </div>
+        <AvgCourseRating avgRating={comparedTimetable.avg_rating} />
       </div>
       <div className="slots-wrapper">
         <div className="horizontal-bar">{commonSlots}</div>


### PR DESCRIPTION
## Description
Makes the compare timetable CSS more consistent and also a little less packed.

Before:
![image](https://user-images.githubusercontent.com/27985363/188284376-d05bc0f6-ab3a-490b-ac50-ef154d74e1d1.png)

After:
![image](https://user-images.githubusercontent.com/27985363/188284354-9dacc212-ddac-4b01-946e-9126e49bd5e1.png)

## Change Log
Just css changes