### PR TITLE
Fix search with empty keyword crashes

### DIFF
--- a/static/js/redux/state/slices/entitiesSlice.ts
+++ b/static/js/redux/state/slices/entitiesSlice.ts
@@ -93,7 +93,7 @@ export const getDenormCourseById = (state: EntitiesSliceState, id: number) => {
 };
 
 export const getSectionTypeToSections = (denormCourse: DenormalizedCourse) => {
-  if (!("sections" in denormCourse)) {
+  if (!denormCourse || !("sections" in denormCourse)) {
     // empty course (only happens on inital CourseInfo state)
     return {};
   }

--- a/static/js/redux/ui/containers/search_side_bar_container.jsx
+++ b/static/js/redux/ui/containers/search_side_bar_container.jsx
@@ -21,9 +21,12 @@ import { timetablesActions } from "../../state/slices/timetablesSlice";
 
 const mapStateToProps = (state) => {
   const courseSections = state.courseSections.objects;
-  let hoveredResult = getSearchResult(state, state.ui.searchHover);
-  if (!hoveredResult) {
-    hoveredResult = getSearchResult(state, 0);
+  let hoveredResult = null;
+  if (state.searchResults.items.length > 0) {
+    hoveredResult = getSearchResult(state, state.ui.searchHover);
+    if (!hoveredResult) {
+      hoveredResult = getSearchResult(state, 0);
+    }
   }
   const activeTimetable = getActiveTimetable(state);
   return {


### PR DESCRIPTION
## Description
Fixes #795 
The bug occurs because `state.ui.searchHover` defaults to `0`. When there is no search result, `state.items[index]` becomes undefined
## Change Log
