### PR TITLE
Fix typo on export calendar modal

### DIFF
--- a/static/js/redux/ui/modals/save_calendar_modal.jsx
+++ b/static/js/redux/ui/modals/save_calendar_modal.jsx
@@ -120,7 +120,7 @@ class SaveCalendarModal extends React.Component {
             <span>Download Calendar</span>
           </button>
           <p className="method-details">
-            Downloads a .ics file which can be uploaded to Google Calendar, loaded in to
+            Downloads a .ics file which can be uploaded to Google Calendar, loaded into
             iCal., or any other calendar application.
           </p>
         </div>


### PR DESCRIPTION
## Description

![image](https://user-images.githubusercontent.com/32407086/190280369-272273c1-b65d-40a6-8df4-6d76bcaae34f.png)

Change 'in to' to 'into'