### PR TITLE
Fix/remove react test utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8222,16 +8222,6 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
     },
-    "envify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/envify/-/envify-0.2.0.tgz",
-      "integrity": "sha1-ZFCRz68Seff4NkqJOwz4HGgOy+A=",
-      "dev": true,
-      "requires": {
-        "falafel": "~0.2.1",
-        "through": "~2.3.4"
-      }
-    },
     "enzyme": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.3.0.tgz",
@@ -10331,22 +10321,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
-    },
-    "falafel": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.2.1.tgz",
-      "integrity": "sha1-nvxRzhnsVykIayKuiJ5dfQ4lZgE=",
-      "dev": true,
-      "requires": {
-        "esprima": "github:substack/esprima#0a7f8489a11b44b019ce168506f535f22d0be290"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "github:substack/esprima#0a7f8489a11b44b019ce168506f535f22d0be290",
-          "from": "github:substack/esprima#0a7f8489a11b44b019ce168506f535f22d0be290",
-          "dev": true
-        }
-      }
     },
     "fast-deep-equal": {
       "version": "1.0.0",
@@ -23877,24 +23851,6 @@
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
-      }
-    },
-    "react-test-utils": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/react-test-utils/-/react-test-utils-0.0.1.tgz",
-      "integrity": "sha1-zWmjfD5Ncm40l+MlRioyeFoZwCY=",
-      "dev": true,
-      "requires": {
-        "envify": "~0.2.0",
-        "react": "~0.8.0"
-      },
-      "dependencies": {
-        "react": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-0.8.0.tgz",
-          "integrity": "sha1-mu8NvD4FtE2WE5zb2qXXJ7BQbh4=",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
     "nock": "^13.2.1",
     "node-sass": "^7.0.0",
     "prettier": "2.5.1",
-    "react-test-utils": "0.0.1",
     "regenerator-runtime": "^0.10.5",
     "sass-loader": "^6.0.7",
     "ts-jest": "^27.1.1",


### PR DESCRIPTION
## Description
Remove `react-test-utils` because its dependency's dependency's dependency is deprecated and no longer exists
## Change Log
