### PR TITLE
Darkmode/scroll bar

### DIFF
--- a/static/css/timetable/base/themes.scss
+++ b/static/css/timetable/base/themes.scss
@@ -26,6 +26,7 @@ $themes: (
   // Light mode
   light:
     (
+      color-scheme-type: light,
       text-color: $primary-navy,
       text-color-hover: $primary-navy,
       background: $g808080,
@@ -50,6 +51,7 @@ $themes: (
   // Dark Mode
   dark:
     (
+      color-scheme-type: dark,
       text-color: $dblue0,
       text-color-hover: white,
       background: $g808080,

--- a/static/css/timetable/framework/page_layout.scss
+++ b/static/css/timetable/framework/page_layout.scss
@@ -56,6 +56,7 @@ textarea {
 @mixin side-bar {
   @include theme() {
     background-color: t("sidebar-background");
+    color-scheme: t("color-scheme-type");
   }
   bottom: auto;
   height: 100%;
@@ -99,6 +100,7 @@ textarea {
   width: calc(100% - 300px);
   @include theme() {
     background-color: t("main-bar-background");
+    color-scheme: t("color-scheme-type");
   }
 
   &.full-cal {


### PR DESCRIPTION
## Description
Set the [`color-scheme` property](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) based on the theme to let the browser automatically apply styling to scroll bars. Might also have some effect on color of other default HTML components like `input`
## Change Log
`static/css/timetable/framework/page_layout.scss`: add `color-scheme` to `side-bar` and `main-bar`
`static/css/timetable/base/themes.scss`: add `color-scheme-type` variable