### PR TITLE
Darkmode/use redux to store theme

### DIFF
--- a/static/js/redux/state/index.tsx
+++ b/static/js/redux/state/index.tsx
@@ -43,6 +43,7 @@ import userAcquisitionModal from "./slices/userAcquisitionModalSlice";
 import compareTimetable from "./slices/compareTimetableSlice";
 import registrar from "./slices/registrarSlice";
 import entities, * as fromEntities from "./slices/entitiesSlice";
+import theme from "./slices/themeSlice";
 import { Slot, Timetable } from "../constants/commonTypes";
 
 export const reducers = {
@@ -69,6 +70,7 @@ export const reducers = {
   signupModal,
   termsOfServiceBanner,
   termsOfServiceModal,
+  theme,
   timetables,
   ui,
   userAcquisitionModal,

--- a/static/js/redux/state/slices/themeSlice.ts
+++ b/static/js/redux/state/slices/themeSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+interface ThemeSliceState {
+  theme: Theme;
+}
+
+type Theme = "light" | "dark";
+const themeLocalStorageKey = "main_theme";
+const availableThemes: Theme[] = ["light", "dark"];
+
+const getInitialTheme = () => {
+  const isBrowserDark =
+    window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const defaultTheme = isBrowserDark ? "dark" : "light";
+  const storedTheme = localStorage.getItem(themeLocalStorageKey) as Theme;
+  const initialTheme =
+    availableThemes.indexOf(storedTheme) === -1 ? defaultTheme : storedTheme;
+  localStorage.setItem(themeLocalStorageKey, initialTheme);
+  return initialTheme;
+};
+
+const initialState: ThemeSliceState = {
+  theme: getInitialTheme(),
+  // slot color state goes here
+};
+
+const themeSlice = createSlice({
+  name: "theme",
+  initialState,
+  reducers: {
+    setTheme: (state, action: PayloadAction<Theme>) => {
+      state.theme = action.payload;
+      localStorage.setItem(themeLocalStorageKey, action.payload);
+    },
+  },
+});
+
+export const { setTheme } = themeSlice.actions;
+export default themeSlice.reducer;

--- a/static/js/redux/ui/ThemeToggle.tsx
+++ b/static/js/redux/ui/ThemeToggle.tsx
@@ -1,6 +1,8 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import Switch from "@mui/material/Switch";
 import { styled } from "@mui/material/styles";
+import { useAppDispatch, useAppSelector } from "../hooks";
+import { setTheme } from "../state/slices/themeSlice";
 
 const ThemeSwitch = styled(Switch)(({ theme }) => ({
   width: 53,
@@ -63,43 +65,19 @@ const ThemeSwitch = styled(Switch)(({ theme }) => ({
  *
  */
 
-// Add more themes here to have it be accepted.
-const availableThemes = ["light", "dark"];
-
 // For typescript purposes
-type Theme = typeof availableThemes[number];
-const themeLocalStorageKey = "main_theme";
-
 const ThemeToggle = () => {
-  const [theme, setTheme] = useState<Theme>("light");
+  const theme = useAppSelector((state) => state.theme.theme);
+  const dispatch = useAppDispatch();
 
-  // On Mount
-  useEffect(() => {
-    const curTheme = localStorage.getItem(themeLocalStorageKey);
-
-    // Check if a theme is valid.
-    if (availableThemes.indexOf(curTheme) !== -1) {
-      setTheme(curTheme);
-    } else {
-      // Set the first element as the default theme
-      setTheme(availableThemes[0]);
-    }
-  }, []);
-
-  // When theme changes
   useEffect(() => {
     // Remove previous theme.
     const root: Element = document.querySelector(".page");
-
     // Reset previous classes
     root.className = "page";
-
     // Now, add the theme
     root.classList.add(`theme--${theme}`);
     root.setAttribute("data-theme", theme);
-
-    // Store in localStorage
-    localStorage.setItem(themeLocalStorageKey, theme);
   }, [theme]);
 
   return (
@@ -107,7 +85,7 @@ const ThemeToggle = () => {
       <ThemeSwitch
         checked={theme === "dark"}
         onChange={(e) => {
-          setTheme(e.target.checked ? "dark" : "light");
+          dispatch(setTheme(e.target.checked ? "dark" : "light"));
         }}
       />
     </div>


### PR DESCRIPTION
## Description
Refactored to use Redux to store theme-related state
Set the default theme as the user browser's theme. 

**Justification**: slot colors must be dynamically determined based on the current theme. Need a common place to store them that can be easily accessed by multiple components.

## Change Log
Created `static/js/redux/state/slices/themeSlice.ts`
Refactored `static/js/redux/ui/ThemeToggle.tsx`