### PR TITLE
Darkmode/show-weekends-switch

### DIFF
--- a/static/js/redux/state/slices/preferencesSlice.ts
+++ b/static/js/redux/state/slices/preferencesSlice.ts
@@ -4,15 +4,18 @@ import { changeActiveSavedTimetable } from "../../actions/initActions";
 import { Timetable } from "../../constants/commonTypes";
 import { getTimetablePreferencesEndpoint } from "../../constants/endpoints";
 import Cookie from "js-cookie";
+import { string } from "prop-types";
 
 interface PreferencesSliceState {
   tryWithConflicts: boolean;
   showWeekend: boolean;
+  theme: string;
 }
 
 const initialState: PreferencesSliceState = {
   tryWithConflicts: false,
   showWeekend: true,
+  theme: "",
 };
 
 export const savePreferences =
@@ -47,6 +50,9 @@ const preferencesSlice = createSlice({
     },
     toggleShowWeekend: (state) => {
       state.showWeekend = !state.showWeekend;
+    },
+    setTheme: (state, { payload }: PayloadAction<string>) => {
+      state.theme = payload;
     },
     setAllPreferences: (state, { payload }: PayloadAction<PreferencesSliceState>) => {
       state.tryWithConflicts = payload.tryWithConflicts;

--- a/static/js/redux/ui/Calendar.tsx
+++ b/static/js/redux/ui/Calendar.tsx
@@ -69,12 +69,16 @@ export const ShowWeekendsSwitch = (props: { isMobile: boolean }) => {
           size="small"
           checked={showWeekend}
           color="default"
-          sx={{ "& .MuiSwitch-switchBase": {
-                  '& + .MuiSwitch-track': {
-                    backgroundColor: theme === "light" ? "" : "#777" 
-                  },
-              }, 
-                "& .MuiSwitch-thumb": { backgroundColor: theme === "light" ? "lightgray" : "#777" }}}
+          sx={{
+            "& .MuiSwitch-switchBase": {
+              "& + .MuiSwitch-track": {
+                backgroundColor: theme === "light" ? "" : "#777",
+              },
+            },
+            "& .MuiSwitch-thumb": {
+              backgroundColor: theme === "light" ? "lightgray" : "#777",
+            },
+          }}
           onChange={() => dispatch(preferencesActions.toggleShowWeekend())}
         />
       </div>

--- a/static/js/redux/ui/Calendar.tsx
+++ b/static/js/redux/ui/Calendar.tsx
@@ -61,6 +61,7 @@ const Row = (props: RowProps) => {
 export const ShowWeekendsButton = (props: { isMobile: boolean }) => {
   const showWeekend = useAppSelector((state) => state.preferences.showWeekend);
   const dispatch = useDispatch();
+  const theme = useAppSelector((state) => state.preferences.theme);
   const button = (
     <Tooltip title={<Typography fontSize={12}>Show Weekends</Typography>}>
       <div className="save-timetable">
@@ -68,7 +69,12 @@ export const ShowWeekendsButton = (props: { isMobile: boolean }) => {
           size="small"
           checked={showWeekend}
           color="default"
-          sx={{ "& .MuiSwitch-thumb": { color: "lightgray" } }}
+          sx={{ "& .MuiSwitch-switchBase": {
+                  '& + .MuiSwitch-track': {
+                    backgroundColor: theme === "light" ? "" : "#777" 
+                  },
+              }, 
+                "& .MuiSwitch-thumb": { backgroundColor: theme === "light" ? "lightgray" : "#777" }}}
           onChange={() => dispatch(preferencesActions.toggleShowWeekend())}
         />
       </div>

--- a/static/js/redux/ui/Calendar.tsx
+++ b/static/js/redux/ui/Calendar.tsx
@@ -58,7 +58,7 @@ const Row = (props: RowProps) => {
   );
 };
 
-export const ShowWeekendsButton = (props: { isMobile: boolean }) => {
+export const ShowWeekendsSwitch = (props: { isMobile: boolean }) => {
   const showWeekend = useAppSelector((state) => state.preferences.showWeekend);
   const dispatch = useDispatch();
   const theme = useAppSelector((state) => state.preferences.theme);
@@ -302,7 +302,7 @@ const Calendar = (props: CalendarProps) => {
   );
   const toolbar = isComparingTimetables ? (
     <>
-      <ShowWeekendsButton isMobile={false} />
+      <ShowWeekendsSwitch isMobile={false} />
     </>
   ) : (
     <>
@@ -312,7 +312,7 @@ const Calendar = (props: CalendarProps) => {
       {shareLink}
       {addNewTimetableButton}
       {saveToCalendarButton}
-      <ShowWeekendsButton isMobile={false} />
+      <ShowWeekendsSwitch isMobile={false} />
     </>
   );
 

--- a/static/js/redux/ui/DayCalendar.tsx
+++ b/static/js/redux/ui/DayCalendar.tsx
@@ -22,7 +22,7 @@ import CellContainer from "./containers/cell_container";
 import { DAYS } from "../constants/constants";
 import { ShareLink } from "./MasterSlot";
 import { useAppSelector } from "../hooks";
-import { ShowWeekendsButton } from "./Calendar";
+import { ShowWeekendsSwitch } from "./Calendar";
 
 type RowProps = {
   isLoggedIn: boolean;
@@ -230,7 +230,7 @@ const DayCalendar = (props: DayCalendarProps) => {
       {addButton}
       {saveButton}
       {saveToCalendarButton}
-      <ShowWeekendsButton isMobile />
+      <ShowWeekendsSwitch isMobile />
     </>
   );
 

--- a/static/js/redux/ui/ThemeToggle.tsx
+++ b/static/js/redux/ui/ThemeToggle.tsx
@@ -83,12 +83,11 @@ const ThemeToggle = () => {
     // Check if a theme is valid.
     if (availableThemes.indexOf(curTheme) !== -1) {
       setTheme(curTheme);
-      dispatch(preferencesActions.setTheme(curTheme))
-      
+      dispatch(preferencesActions.setTheme(curTheme));
     } else {
       // Set the first element as the default theme
       setTheme(availableThemes[0]);
-      dispatch(preferencesActions.setTheme(availableThemes[0]))
+      dispatch(preferencesActions.setTheme(availableThemes[0]));
     }
   }, []);
 
@@ -106,7 +105,7 @@ const ThemeToggle = () => {
 
     // Store in localStorage
     localStorage.setItem(themeLocalStorageKey, theme);
-    dispatch(preferencesActions.setTheme(theme))
+    dispatch(preferencesActions.setTheme(theme));
   }, [theme]);
 
   return (

--- a/static/js/redux/ui/ThemeToggle.tsx
+++ b/static/js/redux/ui/ThemeToggle.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from "react";
 import Switch from "@mui/material/Switch";
 import { styled } from "@mui/material/styles";
+import { useDispatch } from "react-redux";
+import { preferencesActions } from "../state/slices/preferencesSlice";
 
 const ThemeSwitch = styled(Switch)(({ theme }) => ({
   width: 53,
@@ -72,6 +74,7 @@ const themeLocalStorageKey = "main_theme";
 
 const ThemeToggle = () => {
   const [theme, setTheme] = useState<Theme>("light");
+  const dispatch = useDispatch();
 
   // On Mount
   useEffect(() => {
@@ -80,9 +83,12 @@ const ThemeToggle = () => {
     // Check if a theme is valid.
     if (availableThemes.indexOf(curTheme) !== -1) {
       setTheme(curTheme);
+      dispatch(preferencesActions.setTheme(curTheme))
+      
     } else {
       // Set the first element as the default theme
       setTheme(availableThemes[0]);
+      dispatch(preferencesActions.setTheme(availableThemes[0]))
     }
   }, []);
 
@@ -100,6 +106,7 @@ const ThemeToggle = () => {
 
     // Store in localStorage
     localStorage.setItem(themeLocalStorageKey, theme);
+    dispatch(preferencesActions.setTheme(theme))
   }, [theme]);
 
   return (


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/32407086/197639798-3c259430-05e9-40c6-b185-92f530e2eabb.png)

After:
![image](https://user-images.githubusercontent.com/32407086/197639847-2e3269ac-5443-4939-83bc-6f3da0d0105a.png)

Demo:
![show_weekends](https://user-images.githubusercontent.com/32407086/197640604-363f42ae-6d2e-43cf-b238-f13ceaf5bf38.gif)

Approach: 
I wasn't able to dynamically override styles for MUI Switch using an scss file so I added a [theme property](https://github.com/jhuopensource/semesterly/blob/9e3ec98ff6de1f52fd53f01c6c1053ffdc3462c0/static/js/redux/state/slices/preferencesSlice.ts#L12) to the redux store and used the `sx` prop 

Alternative approach:
I tried using a styled component like the [theme toggle](https://github.com/jhuopensource/semesterly/blob/c220881d1b15b3d90df0c49e1f8f1aac4efcabd0/static/js/redux/ui/ThemeToggle.tsx#L5-L52) but that made the Switch animation noticeably slower
