### PR TITLE
News modal: add dark mode

### DIFF
--- a/static/css/timetable/base/themes.scss
+++ b/static/css/timetable/base/themes.scss
@@ -27,6 +27,7 @@ $themes: (
   light:
     (
       background: $g808080,
+      code-snippet-background: $gf3f3f3,
       color-scheme-type: light,
       course-modal-credits: $g999,
       dropdown-background: #fff,
@@ -91,6 +92,7 @@ $themes: (
   dark:
     (
       background: $g808080,
+      code-snippet-background: $dblue7,
       color-scheme-type: dark,
       course-modal-credits: $dblue050,
       dropdown-background: $g333,

--- a/static/css/timetable/partials/news_modal.scss
+++ b/static/css/timetable/partials/news_modal.scss
@@ -28,7 +28,7 @@
     }
 
     h4 {
-      font-size: 1.30em;
+      font-size: 1.3em;
       margin: 0.5em 0 0.5em 0;
       font-weight: bold;
     }
@@ -37,6 +37,25 @@
       font-size: 1.15em;
       margin: 0.5em 0 0.5em 0;
       font-weight: bold;
+    }
+
+    h6 {
+      font-size: 1em;
+      margin: 0.5em 0 0.5em 0;
+      font-weight: bold;
+    }
+
+    pre {
+      @include theme() {
+        background-color: t("code-snippet-background");
+      }
+      border: none;
+      border-radius: 3px;
+      padding: 1em;
+      margin: 1em 0;
+      overflow: auto;
+      font-size: 0.9em;
+      line-height: 1.5em;
     }
 
     p {

--- a/static/css/timetable/partials/news_modal.scss
+++ b/static/css/timetable/partials/news_modal.scss
@@ -28,7 +28,7 @@
     }
 
     h4 {
-      font-size: 1.30em;
+      font-size: 1.3em;
       margin: 0.5em 0 0.5em 0;
       font-weight: bold;
     }
@@ -37,6 +37,25 @@
       font-size: 1.15em;
       margin: 0.5em 0 0.5em 0;
       font-weight: bold;
+    }
+
+    h6 {
+      font-size: 1em;
+      margin: 0.5em 0 0.5em 0;
+      font-weight: bold;
+    }
+
+    pre {
+      @include theme() {
+        background-color: t("modal-header-background");
+      }
+      border: none;
+      border-radius: 3px;
+      padding: 1em;
+      margin: 1em 0;
+      overflow: auto;
+      font-size: 0.9em;
+      line-height: 1.5em;
     }
 
     p {

--- a/static/css/timetable/partials/news_modal.scss
+++ b/static/css/timetable/partials/news_modal.scss
@@ -49,7 +49,7 @@
       @include theme() {
         background-color: t("code-snippet-background");
       }
-      border: none;
+      border: 0;
       border-radius: 3px;
       padding: 1em;
       margin: 1em 0;


### PR DESCRIPTION
## Description

Add dark mode to news modal. Not much work had to be done here, just added had to assign proper background color for `<pre>` tags and fix formatting for `<h6>` tags.

![image](https://user-images.githubusercontent.com/57109640/201002340-52d7cda4-f15f-4978-8785-be589cb7a8a6.png)
![image](https://user-images.githubusercontent.com/57109640/201002352-04c98803-7216-4e1f-b7ce-fe8027e53f4e.png)

## Change Log

- [x] Fix `h6` formatting
- [x] Add dynamic background color for `<pre>` tags
- [x] Add new light/dark theme color: `code-snippet-background`
