### PR TITLE
Fix/advanced-search-horizontal-scroll

### DIFF
--- a/static/css/timetable/partials/course_modal.scss
+++ b/static/css/timetable/partials/course_modal.scss
@@ -298,6 +298,7 @@
 .modal-body {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   width: 100%;
 
   [class^="col-"] {


### PR DESCRIPTION
Remove unnecessary horizontal scrollbar in advanced search modal modal

Before:
![image](https://user-images.githubusercontent.com/32407086/202257475-d62ba469-45ac-4e06-a0c4-00caf6fc6ecc.png)

After:
![image](https://user-images.githubusercontent.com/32407086/202257937-61d5215e-5144-44a3-bf4a-5ec32b01ac35.png)
