### PR TITLE
Darkmode/search bar color

### DIFF
--- a/static/css/timetable/base/themes.scss
+++ b/static/css/timetable/base/themes.scss
@@ -165,7 +165,7 @@ $themes: (
       share-link-text: $dblue0,
       share-link-wrapper: $dblue3,
       sidebar-background: $dark-base-component-bg,
-      sidebar-input-background: $dblue3,
+      sidebar-input-background: $dblue7,
       sidebar-input-border: 1px solid $g222,
       sidebar-input-border_focus: 1px solid $blue-alt,
       sidebar-input-border_hover: 1px solid $dblue3,

--- a/static/css/timetable/base/themes.scss
+++ b/static/css/timetable/base/themes.scss
@@ -136,7 +136,7 @@ $themes: (
       reactions-background: $dblue7,
       reactions-count-background: $dblue6,
       row-button-hover-background-color: $dblue3,
-      search-bar-background: $dblue3,
+      search-bar-background: $dblue7,
       search-bar-box-shadow: $dblue7,
       search-bar-focused-background: $dblue8,
       search-bar-option-background-hover: $dblue2,


### PR DESCRIPTION
Search bar, select semester, and timetable name input should be $dblue7 instead of $dblue3

## Search bar and timetable name input
Before 
![image](https://user-images.githubusercontent.com/32407086/204870980-b25a3312-2264-4929-a070-34b69852349c.png)

After 
![image](https://user-images.githubusercontent.com/32407086/204870651-7c7c8c21-5a2b-4279-8873-8e6cc0033fbf.png)

## Select semester
Before 
![image](https://user-images.githubusercontent.com/32407086/204871081-194a6509-9504-4976-a6e5-3453f058e89b.png)

After
![image](https://user-images.githubusercontent.com/32407086/204871158-a337e0d2-f21f-49de-9008-7588cffdb512.png)
