### PR TITLE
Fix tall letters (p, y, g, etc) having their bottom cut off in search results

### DIFF
--- a/static/css/timetable/partials/search_bar.scss
+++ b/static/css/timetable/partials/search_bar.scss
@@ -223,7 +223,7 @@
     font-size: 14px;
     height: 14px;
     margin: 0;
-    overflow: hidden;
+    overflow: visible;
     padding-left: 5px;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
Before
![after](https://user-images.githubusercontent.com/32407086/204875171-7ab4e702-e65f-4982-b4eb-05d2ee507ce9.png)


After
![after](https://user-images.githubusercontent.com/32407086/204874802-308f25dc-ac9e-4aa7-8fc4-255d9e46d919.png)

