### PR TITLE
Darkmode/fix share timetable tooltip

### DIFF
--- a/static/css/timetable/base/themes.scss
+++ b/static/css/timetable/base/themes.scss
@@ -84,7 +84,7 @@ $themes: (
       share-link-shadow-1: rgba(0, 0, 0, 0.5),
       share-link-shadow-2: rgba(0, 0, 0, 0.15),
       share-link-text: $g222,
-      share-link-wrapper: $gf9f9f9,
+      share-link-wrapper: $gddd,
       short-course-background: $gfff,
       sidebar-background: $light-base-component-bg,
       sidebar-input-background: #f2f3f5,
@@ -100,6 +100,7 @@ $themes: (
       // Use a filter to change the color of img elements (e.g., png icons)
       toolbar-img-icon-hover-filter: invert(23%) sepia(55%) saturate(362%)
         hue-rotate(169deg) brightness(96%) contrast(88%),
+      tooltip-background: $gfff,
       top-bar-background: $light-base-component-bg,
       top-bar-border-bottom: none,
       tos-banner-background: $gfff,
@@ -184,6 +185,7 @@ $themes: (
       // Use a filter to change color of img elements (e.g., png icons)
       toolbar-img-icon-hover-filter: invert(91%) sepia(10%) saturate(390%)
         hue-rotate(173deg) brightness(97%) contrast(89%),
+      tooltip-background: $dblue7,
       top-bar-background: $dark-base-component-bg,
       top-bar-border-bottom: 1px solid $dblue2,
       tos-banner-background: $dblue7,

--- a/static/css/timetable/modules/share_link.scss
+++ b/static/css/timetable/modules/share_link.scss
@@ -1,7 +1,7 @@
 .share-course-link-wrapper {
   @include theme() {
     background-color: t("share-link-wrapper");
-    box-shadow: 0 0 12px t("share-link-shadow-1"), 0 0 1px t("share-link-shadow-2");
+    box-shadow: 0px 2px 6px t("share-link-shadow-1");
   }
   border-radius: 2px;
   max-width: 250px;
@@ -13,7 +13,7 @@
   display: inline-block;
   margin-top: 8px;
   font-size: 12px;
-  cursor:default;
+  cursor: default;
   .tip {
     @include theme() {
       border-color: transparent transparent t("share-link-wrapper");
@@ -39,7 +39,6 @@
     max-width: 240px;
     width: auto;
     cursor: text;
-    border: 1px solid $g222;
     padding: 0 5px;
   }
   .clipboardBtn {

--- a/static/css/timetable/partials/timetable.scss
+++ b/static/css/timetable/partials/timetable.scss
@@ -157,11 +157,12 @@ button {
   align-items: center;
 
   .share-course-link-wrapper {
-    top: auto;
+    @include theme() {
+      background-color: t("tooltip-background");
+    }
     right: auto;
-    display: block;
-    margin-left: -154px !important;
-    margin-top: 36px;
+    margin-left: -154px;
+    margin-top: 40px;
   }
 }
 


### PR DESCRIPTION
## Description

The tooltip that pops up after clicking the Share Calendar button is misaligned.

Before:
![image](https://user-images.githubusercontent.com/57109640/205707389-67012a51-23a2-456b-9469-ee830ad27352.png)

After:
![image](https://user-images.githubusercontent.com/57109640/205707875-7f89e25b-1bc2-4230-bfea-8bffb1531cda.png)

![image](https://user-images.githubusercontent.com/57109640/205707861-a1b5e6a2-2535-4742-835d-6ecb888bcde8.png)

## Change Log

- [x] Fix positioning
- [x] Update background color
- [x] Fix tooltip triangle color on light mode