### PR TITLE
Custom Event: Fix color not changing when event background color is dark

### DIFF
--- a/static/js/redux/ui/CustomSlot.tsx
+++ b/static/js/redux/ui/CustomSlot.tsx
@@ -130,7 +130,6 @@ const CustomSlot = (props: CustomSlotProps) => {
         zIndex: 10,
         right: "0%",
         backgroundColor: theme.customEventDefaultColor,
-        color: "#222",
         width: "100%",
         left: 0,
         opacity: 0.5,
@@ -145,12 +144,10 @@ const CustomSlot = (props: CustomSlotProps) => {
     if (pushLeft === 50) {
       pushLeft += 0.5;
     }
-    const color = tinycolor(props.color).isLight() ? "#222222" : "#FFFFFF";
     return {
       top,
       bottom: -bottom,
       right: "0%",
-      color,
       backgroundColor: props.color,
       width: `${slotWidthPercentage}%`,
       left: `${pushLeft}%`,
@@ -188,6 +185,9 @@ const CustomSlot = (props: CustomSlotProps) => {
     }
   };
 
+  const color = tinycolor(props.color).isLight() ? "#222222" : "#FFFFFF";
+  const coloredSpan = (text: string) => <span style={{ color }}>{text}</span>;
+
   const customSlot = (
     <div
       className={`fc-time-grid-event fc-event slot ${props.preview ? "preview" : ""}`}
@@ -199,29 +199,28 @@ const CustomSlot = (props: CustomSlotProps) => {
     >
       <div
         className="slot-bar"
-        style={{ backgroundColor: tinycolor(props.color).darken(20).toString() }}
+        style={{
+          backgroundColor: tinycolor(props.color).isLight()
+            ? tinycolor(props.color).darken(20).toString()
+            : tinycolor(props.color).lighten(10).toString(),
+        }}
       />
       {removeButton}
       <div className="fc-content">
+        <div className="fc-time">{coloredSpan(props.name)}</div>
         <div className="fc-time">
-          <span>{props.name}</span>
+          {coloredSpan(`${convertedStart} – ${convertedEnd}`)}
         </div>
+        <div className="fc-time">{coloredSpan(props.location)}</div>
         <div className="fc-time">
-          <span>
-            {convertedStart} – {convertedEnd}
-          </span>
-        </div>
-        <div className="fc-time">
-          <span>{props.location}</span>
-        </div>
-        <div className="fc-time">
-          {parseFloat(props.credits) !== 0 && (
-            <span>{`${
-              props.credits.toString().endsWith(".0")
-                ? parseInt(props.credits, 10)
-                : props.credits
-            } credit${parseFloat(props.credits) !== 1 ? "s" : ""}`}</span>
-          )}
+          {parseFloat(props.credits) !== 0 &&
+            coloredSpan(
+              `${
+                props.credits.toString().endsWith(".0")
+                  ? parseInt(props.credits, 10)
+                  : props.credits
+              } credit${parseFloat(props.credits) !== 1 ? "s" : ""}`
+            )}
         </div>
       </div>
     </div>

--- a/static/js/redux/ui/gradientUtils.ts
+++ b/static/js/redux/ui/gradientUtils.ts
@@ -73,7 +73,7 @@ export const gradientToSlotColorData = (color: string, curTheme: ThemeName) => (
   highlight: tinycolor(color).darken(5).toString(),
   border:
     curTheme === "dark"
-      ? tinycolor(color).lighten(20).toString()
+      ? tinycolor(color).lighten(10).toString()
       : tinycolor(color).darken(20).toString(),
   font: "#222",
 });


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/27985363/206810817-21b56cd5-2762-4a63-ade6-90d50e5027fa.png)
Fix Custom Event color text being black even when background is black

The lightened borders were too much in contrast with the dark background; change lighten 20% to lighten 10%, but keep darken 20%
![image](https://user-images.githubusercontent.com/27985363/206810947-c3c78372-529f-4cee-8cff-13fb1b1273f8.png)

## Change Log
