### PR TITLE
Fix/show weekends no fetch

### DIFF
--- a/static/js/redux/actions/initActions.ts
+++ b/static/js/redux/actions/initActions.ts
@@ -64,3 +64,20 @@ export const requestCourses = createAction("global/requestCourses");
 export const setTheme = createAction("global/setTheme", (theme: Theme) => ({
   payload: theme,
 }));
+
+// Preferences related actions
+
+/**
+ * This is required because toggling show weekends does not cause a re-fetch, so we have
+ * to update the timetable state in addition to the preferences state. This is in
+ * contrast to has_conflict/tryWithConflict, which is immediately set because the
+ * timetable is fetched as it automatically adds a course once it's toggled.
+ * 
+ * Note this only matters for savingTimetableSlice & userInfoSlice since when the user 
+ * is not logged in, they can only have one timetable and preferences are handled by 
+ * browser storage, so the timetable can never be out of sync with the preferences.
+ */
+export const setShowWeekend = createAction(
+  "global/setShowWeekend",
+  (showWeekend: boolean) => ({ payload: showWeekend })
+);

--- a/static/js/redux/actions/initActions.ts
+++ b/static/js/redux/actions/initActions.ts
@@ -72,9 +72,9 @@ export const setTheme = createAction("global/setTheme", (theme: Theme) => ({
  * to update the timetable state in addition to the preferences state. This is in
  * contrast to has_conflict/tryWithConflict, which is immediately set because the
  * timetable is fetched as it automatically adds a course once it's toggled.
- * 
- * Note this only matters for savingTimetableSlice & userInfoSlice since when the user 
- * is not logged in, they can only have one timetable and preferences are handled by 
+ *
+ * Note this only matters for savingTimetableSlice & userInfoSlice since when the user
+ * is not logged in, they can only have one timetable and preferences are handled by
  * browser storage, so the timetable can never be out of sync with the preferences.
  */
 export const setShowWeekend = createAction(

--- a/static/js/redux/state/slices/savingTimetableSlice.ts
+++ b/static/js/redux/state/slices/savingTimetableSlice.ts
@@ -3,6 +3,7 @@ import {
   alertTimeTableExists,
   changeActiveSavedTimetable,
   changeActiveTimetable,
+  setShowWeekend,
 } from "../../actions/initActions";
 import { Timetable } from "../../constants/commonTypes";
 
@@ -62,6 +63,9 @@ const savingTimetableSlice = createSlice({
       })
       .addCase(changeActiveTimetable, (state) => {
         state.upToDate = false;
+      })
+      .addCase(setShowWeekend, (state, action: PayloadAction<boolean>) => {
+        state.activeTimetable.show_weekend = action.payload;
       });
   },
 });

--- a/static/js/redux/state/slices/userInfoSlice.ts
+++ b/static/js/redux/state/slices/userInfoSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { initAllState } from "../../actions/initActions";
+import { Timetable } from "../../constants/commonTypes";
 import { isIncomplete } from "../../util";
 
 interface UserData {
@@ -70,6 +71,11 @@ const userInfoSlice = createSlice({
     },
     receiveSavedTimeTables: (state, action: PayloadAction<any>) => {
       state.data.timetables = action.payload;
+    },
+    updateSavedTimetable: (state, action: PayloadAction<Timetable>) => {
+      state.data.timetables = state.data.timetables.map((t: Timetable) =>
+        t.id === action.payload.id ? action.payload : t
+      );
     },
     setUserSettingsModalVisible: (state) => {
       state.isVisible = true;

--- a/static/js/redux/ui/Calendar.tsx
+++ b/static/js/redux/ui/Calendar.tsx
@@ -109,7 +109,10 @@ export const ShowWeekendsSwitch = (props: { isMobile: boolean }) => {
             backgroundColor: theme.name === "light" ? "lightgray" : "#777",
           },
         }}
-        onChange={() => dispatch(preferencesActions.toggleShowWeekend())}
+        onChange={() => {
+          dispatch(preferencesActions.toggleShowWeekend());
+          dispatch(preferencesActions.savePreferences());
+        }}
       />
     </Tooltip>
   );

--- a/static/js/redux/ui/Calendar.tsx
+++ b/static/js/redux/ui/Calendar.tsx
@@ -113,7 +113,6 @@ export const ShowWeekendsSwitch = (props: { isMobile: boolean }) => {
         onChange={() => {
           dispatch(setShowWeekend(!showWeekend));
           dispatch(preferencesActions.savePreferences());
-
         }}
       />
     </Tooltip>

--- a/static/js/redux/ui/Calendar.tsx
+++ b/static/js/redux/ui/Calendar.tsx
@@ -28,6 +28,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 import { selectTheme } from "../state/slices/themeSlice";
+import { setShowWeekend } from "../actions/initActions";
 
 interface RowProps {
   isLoggedIn: boolean;
@@ -110,8 +111,9 @@ export const ShowWeekendsSwitch = (props: { isMobile: boolean }) => {
           },
         }}
         onChange={() => {
-          dispatch(preferencesActions.toggleShowWeekend());
+          dispatch(setShowWeekend(!showWeekend));
           dispatch(preferencesActions.savePreferences());
+
         }}
       />
     </Tooltip>


### PR DESCRIPTION
This fixes showWeekend being untoggled when switching between timetables or refreshing the page *without* a fetchTimetables call. The issue was that the redux state/local preferences was not being updated immediately, but only when a timetable was fetched.

Previous behavior (logged in):
TT 1 -> Toggle show weekends
TT 1 -> TT 2 (Switch timetables)
TT 2 -> TT 1 (Switch timetables again)
TT 1 -> Show weekends untoggled, not saved upon refresh either

New behavior (logged in):
TT 1 -> Toggle show weekends
TT 1 -> TT 2 (Switch timetables)
TT 2 -> TT 1 (Switch timetables again)
TT 1 -> Show weekends remains toggled, and is also saved upon refresh

<hr>

Previous behavior (not logged in):
TT -> toggle weekends
TT -> Refresh
TT -> toggle weekends untoggled

New behavior (not logged in):
TT -> toggle weekends
TT -> Refresh
TT -> toggle weekends remains toggled
