### PR TITLE
Django debug toolbar

### DIFF
--- a/build/local_settings.py
+++ b/build/local_settings.py
@@ -1,7 +1,7 @@
 import os
 
 DEBUG = True
-
+SHOW_DEBUG_TOOLBAR = False
 TEMPLATE_DEBUG = DEBUG
 
 # This configuration relies on environment variables for DB settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ dateparser==1.1.0
 Django==3.2.17
 django-cachalot==2.4.3
 django-ckeditor==6.2.0 
+django-debug-toolbar==3.8.1
 django-extensions==3.1.5
 django-picklefield==3.0.1
 django-webpack-loader==0.7.0
@@ -28,6 +29,7 @@ interruptingcow==0.7
 jsondiff==1.1.1
 jsonschema==3.2.0
 lxml==4.9.1
+markdown==3.4.1
 mock==2.0.0
 nltk==3.6.6
 numpy==1.22.0

--- a/semesterly/settings.py
+++ b/semesterly/settings.py
@@ -356,5 +356,5 @@ if not DEBUG:
     rollbar.init(**ROLLBAR)
 
 DEBUG_TOOLBAR_CONFIG = {
-    "SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG # show django debug toolbar if debug mode
+    "SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG  # show django debug toolbar if debug mode
 }

--- a/semesterly/settings.py
+++ b/semesterly/settings.py
@@ -62,6 +62,8 @@ SECRET_KEY = get_secret("SECRET_KEY")
 
 DEBUG = True
 
+SHOW_DEBUG_TOOLBAR = False
+
 ALLOWED_HOSTS = ["*"]
 
 USE_X_FORWARDED_HOST = True
@@ -173,7 +175,6 @@ INSTALLED_APPS = (
     "student",
     "timetable",
     "ckeditor",
-    "debug_toolbar",
 )
 
 REST_FRAMEWORK = {"UNICODE_JSON": False}
@@ -185,7 +186,6 @@ MIDDLEWARE = (
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
@@ -355,6 +355,7 @@ if not DEBUG:
 
     rollbar.init(**ROLLBAR)
 
-DEBUG_TOOLBAR_CONFIG = {
-    "SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG  # show django debug toolbar if debug mode
-}
+if SHOW_DEBUG_TOOLBAR:
+    DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda request: True}
+    INSTALLED_APPS += ("debug_toolbar",)
+    MIDDLEWARE += ("debug_toolbar.middleware.DebugToolbarMiddleware",)

--- a/semesterly/settings.py
+++ b/semesterly/settings.py
@@ -173,6 +173,7 @@ INSTALLED_APPS = (
     "student",
     "timetable",
     "ckeditor",
+    "debug_toolbar",
 )
 
 REST_FRAMEWORK = {"UNICODE_JSON": False}
@@ -184,6 +185,7 @@ MIDDLEWARE = (
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
@@ -352,3 +354,7 @@ if not DEBUG:
     import rollbar
 
     rollbar.init(**ROLLBAR)
+
+DEBUG_TOOLBAR_CONFIG = {
+    "SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG # show django debug toolbar if debug mode
+}

--- a/semesterly/urls.py
+++ b/semesterly/urls.py
@@ -86,5 +86,5 @@ if getattr(settings, "DEBUG", True):
             schema_view.with_ui("swagger", cache_timeout=0),
             name="schema-swagger-ui",
         ),
-        re_path(r"^__debug__/", include('debug_toolbar.urls')),
+        re_path(r"^__debug__/", include("debug_toolbar.urls")),
     ]

--- a/semesterly/urls.py
+++ b/semesterly/urls.py
@@ -86,4 +86,5 @@ if getattr(settings, "DEBUG", True):
             schema_view.with_ui("swagger", cache_timeout=0),
             name="schema-swagger-ui",
         ),
+        re_path(r"^__debug__/", include('debug_toolbar.urls')),
     ]

--- a/semesterly/urls.py
+++ b/semesterly/urls.py
@@ -86,5 +86,8 @@ if getattr(settings, "DEBUG", True):
             schema_view.with_ui("swagger", cache_timeout=0),
             name="schema-swagger-ui",
         ),
+    ]
+if settings.SHOW_DEBUG_TOOLBAR:
+    urlpatterns += [
         re_path(r"^__debug__/", include("debug_toolbar.urls")),
     ]


### PR DESCRIPTION
## Description
Added Django Debug Toolbar to help with debugging the backend API speed.
Whether debug toolbar loads is controlled by the `SHOW_DEBUG_TOOLBAR` variable.
The default is `False` as set in `settings.py` but can be overridden with configs in `local_settings.py`
![image](https://user-images.githubusercontent.com/37493948/217414979-33916875-c901-4a41-8c1d-8fc2ca8f9cda.png)

## Change Log
