### PR TITLE
Timetable: Expand to 24 hours and make it auto-scroll to best view

### DIFF
--- a/searches/tests.py
+++ b/searches/tests.py
@@ -81,6 +81,30 @@ class BasicSearchTest(APITestCase):
     def test_search_empty(self):
         searchAssertEmptyResponse(self, {}, "/search/Winter/1995/asdf")
 
+    def test_search_abbreviation(self):
+        sem = Semester.objects.create(name="Winter", year="1996")
+        course = Course.objects.create(
+            school=self.school,
+            code="SEA102",
+            name="Data Structures",
+            level=100,
+            areas=["E", "Q"],
+            department="Computer Science",
+        )
+        section = Section.objects.create(
+            course=course, semester=sem, meeting_section="L1", section_type="L"
+        )
+        Offering.objects.create(
+            section=section,
+            day="M",
+            date_start="08-29-1996",
+            date_end="12-10-1996",
+            time_start="8:00",
+            time_end="10:00",
+            is_short_course=False,
+        )
+        searchAssertNonemptyResponse(self, {}, "/search/Winter/1996/ds")
+
 
 class AdvancedSearchTest(APITestCase):
     school = "uoft"

--- a/semesterly/test_utils.py
+++ b/semesterly/test_utils.py
@@ -948,8 +948,8 @@ class SeleniumTestCase(StaticLiveServerTestCase):
 
         Args:
             day: 0-6, 0 is Monday
-            start_time: 0 is 8:00A.M, every 1 is 30 mins
-            end_time: 0 is 8:00A.M, every 1 is 30 mins
+            start_time: 0 is 0:00A.M, every 1 is 30 mins
+            end_time: 0 is 0:00A.M, every 1 is 30 mins
             show_weekend: if weekends are shown
         """
         calendar_cells = self.find((By.CLASS_NAME, "cal-cell"), get_all=True)

--- a/semesterly/tests.py
+++ b/semesterly/tests.py
@@ -209,7 +209,7 @@ class EndToEndTest(SeleniumTestCase):
             self.delete_timetable("End To End Testing!")
             self.assert_timetable_not_found("End To End Testing!")
         with self.description("Add and edit custom events"):
-            self.create_custom_event(4, 0, 4, False)
+            self.create_custom_event(4, 16, 20, False)
             self.assert_custom_event_exists(
                 name="New Custom Event", start_time="8:00", end_time="10:00"
             )

--- a/semesterly/tests.py
+++ b/semesterly/tests.py
@@ -91,7 +91,6 @@ class EndToEndTest(SeleniumTestCase):
             self.select_nth_adv_search_result(1, sem)
             self.select_nth_adv_search_result(2, sem)
 
-    @unittest.skip("")
     def test_logged_in_via_fb_flow(self):
         with self.description("Setup and clear tutorial"):
             self.clear_tutorial()
@@ -125,7 +124,6 @@ class EndToEndTest(SeleniumTestCase):
             self.login_via_fb(email="e@ma.il", password="password")
             self.assert_ptt_equals(ptt)
 
-    @unittest.skip("")
     def test_logged_in_via_google_flow(self):
         with self.description("Setup and clear tutorial"):
             self.clear_tutorial()

--- a/semesterly/tests.py
+++ b/semesterly/tests.py
@@ -91,6 +91,7 @@ class EndToEndTest(SeleniumTestCase):
             self.select_nth_adv_search_result(1, sem)
             self.select_nth_adv_search_result(2, sem)
 
+    @unittest.skip("")
     def test_logged_in_via_fb_flow(self):
         with self.description("Setup and clear tutorial"):
             self.clear_tutorial()
@@ -124,6 +125,7 @@ class EndToEndTest(SeleniumTestCase):
             self.login_via_fb(email="e@ma.il", password="password")
             self.assert_ptt_equals(ptt)
 
+    @unittest.skip("")
     def test_logged_in_via_google_flow(self):
         with self.description("Setup and clear tutorial"):
             self.clear_tutorial()

--- a/static/css/timetable/framework/page_layout.scss
+++ b/static/css/timetable/framework/page_layout.scss
@@ -62,7 +62,7 @@ textarea {
   height: 100%;
   left: calc(100% - 300px);
   overflow-y: auto;
-  padding: 20px 10px 70px 0;
+  padding: 20px 10px 70px 10px;
   position: absolute;
   top: 0;
   transform: translateX(0);
@@ -94,7 +94,7 @@ textarea {
   height: 100%;
   opacity: 1;
   overflow-y: auto;
-  padding: 0 20px;
+  padding: 0 0 0 20px;
   transition: width 0.3s, opacity 0.3s, visibility 0.3s;
   visibility: visible;
   width: calc(100% - 300px);
@@ -198,7 +198,7 @@ textarea {
     bottom: 0;
     left: 100%;
     overflow-y: auto;
-    padding: 10px 10px 100px;
+    padding: 10px 10px 100px 10px;
     position: fixed;
     top: 50px;
     transform: translateX(0%);
@@ -217,7 +217,7 @@ textarea {
 
 @media (max-width: 766px) {
   .main-bar {
-    padding: 10px;
+    padding: 10px 0px 10px 10px;
   }
 
   .show-advanced-search {
@@ -365,6 +365,7 @@ li {
 
 footer {
   background-color: transparent;
+  margin-bottom: 0px;
 
   .nav {
     margin: 5px 0;

--- a/static/css/timetable/partials/timetable.scss
+++ b/static/css/timetable/partials/timetable.scss
@@ -181,3 +181,7 @@ button {
     }
   }
 }
+
+.timetable-footer {
+  margin-bottom: 0px;
+}

--- a/static/css/timetable/vendor/full-calendar.scss
+++ b/static/css/timetable/vendor/full-calendar.scss
@@ -616,6 +616,8 @@ a.fc-more:hover {
 .fc-view > table {
   position: relative;
   z-index: 1;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .fc-basicDay-view .fc-content-skeleton,

--- a/static/js/redux/__tests__/selectors.test.jsx
+++ b/static/js/redux/__tests__/selectors.test.jsx
@@ -1,5 +1,6 @@
 import { getFirstTTStartHour } from "../state";
 import { getSectionTypeToSections } from "../state/slices/entitiesSlice";
+import { emptyTimetable } from "../state/slices/timetablesSlice";
 
 describe("course selectors", () => {
   describe("section type to sections selector", () => {
@@ -46,7 +47,7 @@ describe("timetable selectors", () => {
 
   describe("getMinTTStartHour", () => {
     it("returns 24 for empty timetable", () => {
-      expect(getFirstTTStartHour({ courses: [], slots: [] })).toEqual(17);
+      expect(getFirstTTStartHour(emptyTimetable)).toEqual(24);
     });
     it("returns correct start hour", () => {
       expect(getFirstTTStartHour(timetable)).toEqual(18);

--- a/static/js/redux/__tests__/selectors.test.jsx
+++ b/static/js/redux/__tests__/selectors.test.jsx
@@ -1,5 +1,7 @@
-import { getFirstTTStartHour } from "../state";
-import { getSectionTypeToSections } from "../state/slices/entitiesSlice";
+import {
+  getSectionTypeToSections,
+  getFirstTTStartHour,
+} from "../state/slices/entitiesSlice";
 import { emptyTimetable } from "../state/slices/timetablesSlice";
 
 describe("course selectors", () => {
@@ -38,11 +40,13 @@ describe("timetable selectors", () => {
           {
             id: "O1",
             thing: "thing",
-            time_end: "18:30",
+            time_start: "18:00",
+            time_end: "18:50",
           },
         ],
       },
     ],
+    events: [],
   };
 
   describe("getMinTTStartHour", () => {

--- a/static/js/redux/__tests__/selectors.test.jsx
+++ b/static/js/redux/__tests__/selectors.test.jsx
@@ -1,4 +1,5 @@
-import { getSectionTypeToSections, getMaxEndHour } from "../state/slices/entitiesSlice";
+import { getFirstTTStartHour } from "../state";
+import { getSectionTypeToSections } from "../state/slices/entitiesSlice";
 
 describe("course selectors", () => {
   describe("section type to sections selector", () => {
@@ -42,12 +43,13 @@ describe("timetable selectors", () => {
       },
     ],
   };
-  describe("getMaxEndHour", () => {
-    it("returns 17 for empty timetable", () => {
-      expect(getMaxEndHour({ courses: [], slots: [] })).toEqual(17);
+
+  describe("getMinTTStartHour", () => {
+    it("returns 24 for empty timetable", () => {
+      expect(getFirstTTStartHour({ courses: [], slots: [] })).toEqual(17);
     });
-    it("returns correct end hour", () => {
-      expect(getMaxEndHour(timetable)).toEqual(19);
+    it("returns correct start hour", () => {
+      expect(getFirstTTStartHour(timetable)).toEqual(18);
     });
   });
 });

--- a/static/js/redux/actions/timetable_actions.jsx
+++ b/static/js/redux/actions/timetable_actions.jsx
@@ -40,7 +40,7 @@ import {
   receiveCourses,
   changeActiveSavedTimetable,
 } from "./initActions";
-import { timetablesActions } from "../state/slices/timetablesSlice";
+import { timetablesActions, emptyTimetable } from "../state/slices/timetablesSlice";
 import { semesterActions } from "../state/slices/semesterSlice";
 import { customEventsActions } from "../state/slices/customEventsSlice";
 import { courseSectionsActions } from "../state/slices/courseSectionsSlice";
@@ -217,17 +217,11 @@ export const createNewTimetable =
   };
 
 export const nullifyTimetable = () => (dispatch) => {
-  dispatch(receiveTimetables([{ slots: [] }]));
+  dispatch(receiveTimetables([emptyTimetable]));
   dispatch(courseSectionsActions.receiveCourseSections({}));
   dispatch(
     changeActiveSavedTimetable({
-      timetable: {
-        name: "Untitled Schedule",
-        slots: [],
-        events: [],
-        has_conflict: false,
-        show_weekend: false,
-      },
+      timetable: emptyTimetable,
       upToDate: false,
     })
   );

--- a/static/js/redux/state/index.tsx
+++ b/static/js/redux/state/index.tsx
@@ -117,9 +117,7 @@ export const getFirstTTStartHour = createSelector(
 export const getHoveredSlots = (state: RootState) =>
   fromTimetables.getHoveredSlots(state.timetables);
 
-export const getMaxEndHour = (state: RootState) => {
-  return 24;
-};
+export const getMaxEndHour = (state: RootState) => 24;
 
 // search selectors
 const getSearchResultId = (state: RootState, index: number) =>

--- a/static/js/redux/state/index.tsx
+++ b/static/js/redux/state/index.tsx
@@ -14,7 +14,6 @@ GNU General Public License for more details.
 
 import { configureStore } from "@reduxjs/toolkit";
 import { createSelector } from "reselect";
-import { getMaxHourBasedOnWindowHeight } from "../util";
 import school from "./slices/schoolSlice";
 import semester, * as fromSemester from "../state/slices/semesterSlice";
 import calendar from "./slices/calendarSlice";
@@ -109,18 +108,18 @@ export const getActiveTimetableDenormCourses = (state: RootState) =>
 export const getCoursesFromSlots = (state: RootState, slots: Slot[]) =>
   fromEntities.getCoursesFromSlots(state.entities, slots);
 
-export const getMaxTTEndHour = createSelector(
+export const getFirstTTStartHour = createSelector(
   // @ts-ignore
   [getActiveDenormTimetable],
-  fromEntities.getMaxEndHour
+  fromEntities.getFirstTTStartHour
 );
 
 export const getHoveredSlots = (state: RootState) =>
   fromTimetables.getHoveredSlots(state.timetables);
 
-// Don't use createSelector to memoize getMaxEndHour
-export const getMaxEndHour = (state: RootState) =>
-  Math.max(getMaxTTEndHour(state), getMaxHourBasedOnWindowHeight());
+export const getMaxEndHour = (state: RootState) => {
+  return 24;
+};
 
 // search selectors
 const getSearchResultId = (state: RootState, index: number) =>

--- a/static/js/redux/state/index.tsx
+++ b/static/js/redux/state/index.tsx
@@ -117,7 +117,8 @@ export const getFirstTTStartHour = createSelector(
 export const getHoveredSlots = (state: RootState) =>
   fromTimetables.getHoveredSlots(state.timetables);
 
-export const getMaxEndHour = (state: RootState) => 24;
+// It's actually 23 because 24 will show up to 00:59
+export const getMaxEndHour = (state: RootState) => 23;
 
 // search selectors
 const getSearchResultId = (state: RootState, index: number) =>

--- a/static/js/redux/state/slices/entitiesSlice.ts
+++ b/static/js/redux/state/slices/entitiesSlice.ts
@@ -152,9 +152,7 @@ export const getTimetableDenormCourses = (
   return courseIds.map((courseId) => getDenormCourseById(state, courseId));
 };
 
-export const getFirstTTStartHour = function getLatestSlotEndHourFromTimetable(
-  timetable: Timetable
-) {
+export const getFirstTTStartHour = (timetable: Timetable) => {
   let firstStartHour = 24;
   timetable.slots.forEach((slot) => {
     slot.offerings.forEach((offering: any) => {

--- a/static/js/redux/state/slices/entitiesSlice.ts
+++ b/static/js/redux/state/slices/entitiesSlice.ts
@@ -152,17 +152,21 @@ export const getTimetableDenormCourses = (
   return courseIds.map((courseId) => getDenormCourseById(state, courseId));
 };
 
-export const getMaxEndHour = function getLatestSlotEndHourFromTimetable(
+export const getFirstTTStartHour = function getLatestSlotEndHourFromTimetable(
   timetable: Timetable
 ) {
-  let maxEndHour = 17;
+  let firstStartHour = 24;
   timetable.slots.forEach((slot) => {
     slot.offerings.forEach((offering: any) => {
-      const endHour = parseInt(offering.time_end.split(":")[0], 10) + 1;
-      maxEndHour = Math.max(maxEndHour, endHour);
+      const startHour = parseInt(offering.time_start.split(":")[0], 10);
+      firstStartHour = Math.min(firstStartHour, startHour);
     });
   });
-  return maxEndHour;
+  timetable.events.forEach((event) => {
+    const startHour = parseInt(event.time_start.split(":")[0], 10);
+    firstStartHour = Math.min(firstStartHour, startHour);
+  });
+  return firstStartHour;
 };
 
 export default entitiesSlice.reducer;

--- a/static/js/redux/state/slices/savingTimetableSlice.ts
+++ b/static/js/redux/state/slices/savingTimetableSlice.ts
@@ -6,6 +6,7 @@ import {
   setShowWeekend,
 } from "../../actions/initActions";
 import { Timetable } from "../../constants/commonTypes";
+import { emptyTimetable } from "./timetablesSlice";
 
 interface SavingTimetableSliceState {
   activeTimetable: Timetable;
@@ -14,15 +15,7 @@ interface SavingTimetableSliceState {
 }
 
 const initialState: SavingTimetableSliceState = {
-  activeTimetable: {
-    name: "Untitled Schedule",
-    id: null,
-    slots: [],
-    has_conflict: null,
-    show_weekend: null,
-    avg_rating: null,
-    events: [],
-  },
+  activeTimetable: emptyTimetable,
   saving: false, // true if we are currently waiting for a response from the backend
   upToDate: false,
 };

--- a/static/js/redux/state/slices/timetablesSlice.ts
+++ b/static/js/redux/state/slices/timetablesSlice.ts
@@ -108,9 +108,8 @@ const timetablesSlice = createSlice({
 });
 export const getTimetables = (state: TimetablesSliceState) => state.items;
 
-export const getActiveTimetable = (state: TimetablesSliceState) => {
-  return state.items[state.active];
-};
+export const getActiveTimetable = (state: TimetablesSliceState) =>
+  state.items[state.active];
 
 export const getHoveredSlots = (state: TimetablesSliceState) => state.hovered;
 

--- a/static/js/redux/state/slices/timetablesSlice.ts
+++ b/static/js/redux/state/slices/timetablesSlice.ts
@@ -89,7 +89,6 @@ const timetablesSlice = createSlice({
         state.isFetching = false;
       })
       .addCase(receiveTimetables, (state, action: PayloadAction<Timetable[]>) => {
-        console.log("Payload", action.payload);
         // if the array of timetables is empty, set state.items to an array with one empty timetable
         const actionTimetables =
           action.payload.length > 0 ? action.payload : [emptyTimetable];
@@ -110,7 +109,6 @@ const timetablesSlice = createSlice({
 export const getTimetables = (state: TimetablesSliceState) => state.items;
 
 export const getActiveTimetable = (state: TimetablesSliceState) => {
-  console.log("State", state);
   return state.items[state.active];
 };
 

--- a/static/js/redux/state/slices/timetablesSlice.ts
+++ b/static/js/redux/state/slices/timetablesSlice.ts
@@ -24,14 +24,14 @@ interface TimetablesSliceState {
   // either int (course id), object (custom slots state), or null
 }
 
-const emptyTimetable: Timetable = {
+export const emptyTimetable: Timetable = {
   slots: [],
   has_conflict: false,
   show_weekend: false,
   id: null,
-  avg_rating: 0,
+  avg_rating: null,
   events: [],
-  name: "",
+  name: "Untitled Schedule",
 };
 
 const initialState: TimetablesSliceState = {
@@ -89,6 +89,7 @@ const timetablesSlice = createSlice({
         state.isFetching = false;
       })
       .addCase(receiveTimetables, (state, action: PayloadAction<Timetable[]>) => {
+        console.log("Payload", action.payload);
         // if the array of timetables is empty, set state.items to an array with one empty timetable
         const actionTimetables =
           action.payload.length > 0 ? action.payload : [emptyTimetable];
@@ -108,8 +109,10 @@ const timetablesSlice = createSlice({
 });
 export const getTimetables = (state: TimetablesSliceState) => state.items;
 
-export const getActiveTimetable = (state: TimetablesSliceState) =>
-  state.items[state.active];
+export const getActiveTimetable = (state: TimetablesSliceState) => {
+  console.log("State", state);
+  return state.items[state.active];
+};
 
 export const getHoveredSlots = (state: TimetablesSliceState) => state.hovered;
 

--- a/static/js/redux/ui/Calendar.tsx
+++ b/static/js/redux/ui/Calendar.tsx
@@ -55,17 +55,7 @@ interface CalendarProps {
 }
 
 const getTimelineStyle = (endHour: number) => {
-  const now = new Date();
-  if (
-    now.getHours() > endHour || // if the current time is before
-    now.getHours() < 8 || // 8am or after the schedule end
-    now.getDay() === 0 || // time or if the current day is
-    now.getDay() === 6 // Saturday or Sunday, then
-  ) {
-    // display no line
-    return { display: "none" };
-  }
-  const diff = Math.abs(new Date().valueOf() - new Date().setHours(8, 0, 0).valueOf());
+  const diff = Math.abs(new Date().valueOf() - new Date().setHours(0, 0, 0).valueOf());
   const mins = Math.ceil(diff / 1000 / 60);
   const top = (mins / 15.0) * 13;
   return { top, zIndex: 1 };

--- a/static/js/redux/ui/Calendar.tsx
+++ b/static/js/redux/ui/Calendar.tsx
@@ -12,7 +12,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 */
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useDispatch } from "react-redux";
 import classnames from "classnames";
 import Clipboard from "clipboard";
@@ -29,6 +29,9 @@ import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 import { selectTheme } from "../state/slices/themeSlice";
 import { setShowWeekend } from "../actions/initActions";
+import { getMaxTimetableHeightBasedOnWindowHeight } from "../util";
+import useWindowSize from "../hooks/useWindowSize";
+import { getFirstTTStartHour } from "../state";
 
 interface RowProps {
   isLoggedIn: boolean;
@@ -138,6 +141,8 @@ const Calendar = (props: CalendarProps) => {
   const [shareLinkShown, setShareLinkShown] = useState(false);
   const [customEventModeOn, setCustomEventModeOn] = useState(false);
   const [timelineStyle, setTimelineStyle] = useState(getTimelineStyle(props.endHour));
+  const [windowHeight, setWindowHeight] = useState(window.innerHeight);
+  const [height] = useWindowSize();
 
   useEffect(() => {
     setInterval(() => {
@@ -147,7 +152,7 @@ const Calendar = (props: CalendarProps) => {
 
   const getCalendarRows = () => {
     const rows = [];
-    for (let i = 8; i <= props.endHour; i++) {
+    for (let i = 0; i <= props.endHour; i++) {
       // one row for each hour, starting from 8am
       const hour = props.uses12HrTime && i > 12 ? i - 12 : i;
       rows.push(
@@ -332,6 +337,19 @@ const Calendar = (props: CalendarProps) => {
     </>
   );
 
+  const timetableParentDivRef = useRef<HTMLDivElement>(null);
+  const firstTTStartHour = useAppSelector(getFirstTTStartHour);
+  // This is needed because React doesn't detect when the window innerHeight changes
+  useEffect(() => {
+    setWindowHeight(window.innerHeight);
+    // Hard-coded hour height because not sure how to get it post-render
+    const hourHeight = 25 * 2;
+    timetableParentDivRef.current?.scroll({
+      top: hourHeight * firstTTStartHour,
+      behavior: "smooth",
+    });
+  }, [height]);
+
   return (
     <div
       className={classnames("calendar fc fc-ltr fc-unthemed week-calendar", {
@@ -348,7 +366,11 @@ const Calendar = (props: CalendarProps) => {
         <div className="fc-clear" />
       </div>
       <div className="fc-view-container" style={{ position: "relative" }}>
-        <div className="fc-view fc-settimana-view fc-agenda-view">
+        <div
+          className="fc-view fc-settimana-view fc-agenda-view"
+          style={{ height: getMaxTimetableHeightBasedOnWindowHeight(windowHeight) }}
+          ref={timetableParentDivRef}
+        >
           <table>
             <thead className="fc-head">
               <tr>

--- a/static/js/redux/ui/CustomSlot.tsx
+++ b/static/js/redux/ui/CustomSlot.tsx
@@ -122,11 +122,9 @@ const CustomSlot = (props: CustomSlotProps) => {
     const endMinute = parseInt(props.time_end.split(":")[1], 10);
 
     const top =
-      (startHour - 8) * (HALF_HOUR_HEIGHT * 2 + 2) +
-      startMinute * (HALF_HOUR_HEIGHT / 30);
+      startHour * (HALF_HOUR_HEIGHT * 2 + 2) + startMinute * (HALF_HOUR_HEIGHT / 30);
     const bottom =
-      (endHour - 8) * (HALF_HOUR_HEIGHT * 2 + 2) +
-      (endMinute * (HALF_HOUR_HEIGHT / 30) - 1);
+      endHour * (HALF_HOUR_HEIGHT * 2 + 2) + (endMinute * (HALF_HOUR_HEIGHT / 30) - 1);
     if (props.preview) {
       // don't take into account conflicts, reduce opacity, increase z-index
       return {

--- a/static/js/redux/ui/DayCalendar.tsx
+++ b/static/js/redux/ui/DayCalendar.tsx
@@ -114,13 +114,8 @@ const DayCalendar = (props: DayCalendarProps) => {
   };
 
   const getTimelineStyle = () => {
-    const now = new Date();
-    // don't show line if the current time is before 8am or after the schedule end
-    if (now.getHours() > props.endHour || now.getHours() < 8) {
-      return { display: "none" };
-    }
     const diff = Math.abs(
-      new Date().valueOf() - new Date().setHours(8, 0, 0).valueOf()
+      new Date().valueOf() - new Date().setHours(0, 0, 0).valueOf()
     );
     const mins = Math.ceil(diff / 1000 / 60);
     const top = (mins / 15.0) * 13;

--- a/static/js/redux/ui/DayCalendar.tsx
+++ b/static/js/redux/ui/DayCalendar.tsx
@@ -129,7 +129,7 @@ const DayCalendar = (props: DayCalendarProps) => {
 
   const getCalendarRows = () => {
     const rows = [];
-    for (let i = 8; i <= props.endHour; i++) {
+    for (let i = 0; i <= props.endHour; i++) {
       // one row for each hour, starting from 8am
       const hour = props.uses12HrTime && i > 12 ? i - 12 : i;
       rows.push(

--- a/static/js/redux/ui/Semesterly.tsx
+++ b/static/js/redux/ui/Semesterly.tsx
@@ -169,7 +169,7 @@ const Semesterly = () => {
       <div className="all-cols">
         <div className={mainbarClassName}>
           {cal}
-          <footer className="footer navbar no-print">
+          <footer className="timetable-footer navbar no-print">
             <p className="data-last-updated no-print">
               Data last updated:{" "}
               {dataLastUpdated && dataLastUpdated.length && dataLastUpdated !== "null"

--- a/static/js/redux/ui/Slot.tsx
+++ b/static/js/redux/ui/Slot.tsx
@@ -113,12 +113,9 @@ const Slot = (props: SlotProps) => {
     const endMinute = parseInt(props.time_end.split(":")[1], 10);
 
     const top =
-      (startHour - 8) * (HALF_HOUR_HEIGHT * 2 + 2) +
-      startMinute * (HALF_HOUR_HEIGHT / 30);
+      startHour * (HALF_HOUR_HEIGHT * 2 + 2) + startMinute * (HALF_HOUR_HEIGHT / 30);
     const bottom =
-      (endHour - 8) * (HALF_HOUR_HEIGHT * 2 + 2) +
-      endMinute * (HALF_HOUR_HEIGHT / 30) -
-      1;
+      endHour * (HALF_HOUR_HEIGHT * 2 + 2) + endMinute * (HALF_HOUR_HEIGHT / 30) - 1;
     // the cumulative width of this slot and all of the slots it is conflicting with
     const totalSlotWidth = 100 - 7 * props.depth_level;
     // the width of this particular slot

--- a/static/js/redux/util.jsx
+++ b/static/js/redux/util.jsx
@@ -106,7 +106,7 @@ export const getLocalTimetable = () => {
 export const getMaxTimetableHeightBasedOnWindowHeight = (height) => {
   // Hard-coded hour height because not sure how to get it post-render
   const hourHeight = 25 * 2;
-  const otherElementsHeight = 150; // Ex: Topbar, toolbar, footer
+  const otherElementsHeight = 140; // Ex: Topbar, toolbar, footer
   const maxHour = parseInt((height - otherElementsHeight) / hourHeight, 10);
   const maxHeight = maxHour * hourHeight;
   const height24Hours = 24 * hourHeight;

--- a/static/js/redux/util.jsx
+++ b/static/js/redux/util.jsx
@@ -103,22 +103,14 @@ export const getLocalTimetable = () => {
   }
 };
 
-export const getMaxHourBasedOnWindowHeight = () => {
-  const calRow = $(".cal-row");
-  const lastRowY = calRow.last().position();
-  if (!lastRowY) {
-    return 0;
-  }
-  const lastHour = 7 + calRow.length / 2;
-  const hourHeight = calRow.height() * 2;
-  const maxHour = parseInt(
-    lastHour + ($(document).height() - 250 - lastRowY.top) / hourHeight,
-    10
-  );
-  if (maxHour < lastHour) {
-    return lastHour;
-  }
-  return Math.min(24, parseInt(maxHour, 10));
+export const getMaxTimetableHeightBasedOnWindowHeight = (height) => {
+  // Hard-coded hour height because not sure how to get it post-render
+  const hourHeight = 25 * 2;
+  const otherElementsHeight = 150; // Ex: Topbar, toolbar, footer
+  const maxHour = parseInt((height - otherElementsHeight) / hourHeight, 10);
+  const maxHeight = maxHour * hourHeight;
+  const height24Hours = 24 * hourHeight;
+  return Math.min(maxHeight, height24Hours);
 };
 
 /*

--- a/timetable/utils.py
+++ b/timetable/utils.py
@@ -270,10 +270,10 @@ def find_slots_to_fill(start, end, school):
 
 def get_time_index(hours, minutes, school):
     """Take number of hours and minutes, and return the corresponding time slot index"""
-    # earliest possible hour is 8, so we get the number of hours past 8am
-    return (hours) * (60 / SCHOOLS_MAP[school].granularity) + minutes / SCHOOLS_MAP[
-        school
-    ].granularity
+    return (
+        hours * (60 / SCHOOLS_MAP[school].granularity)
+        + minutes / SCHOOLS_MAP[school].granularity
+    )
 
 
 def get_hours_minutes(time_string):
@@ -305,8 +305,6 @@ def get_minute_from_string_time(time_string):
 def get_day_to_usage(custom_events, school):
     """Initialize day_to_usage dictionary, which has custom events blocked out."""
     day_to_usage = {
-        # This really should be 24 * 60, but for some reason the timetable is
-        # capped at starting at 8am, so 8am-12am is 16 hours.
         day: [set() for _ in range(int(24 * 60 / SCHOOLS_MAP[school].granularity))]
         for day in ["M", "T", "W", "R", "F", "S", "U"]
     }

--- a/timetable/utils.py
+++ b/timetable/utils.py
@@ -271,7 +271,7 @@ def find_slots_to_fill(start, end, school):
 def get_time_index(hours, minutes, school):
     """Take number of hours and minutes, and return the corresponding time slot index"""
     # earliest possible hour is 8, so we get the number of hours past 8am
-    return (hours - 8) * (60 / SCHOOLS_MAP[school].granularity) + minutes / SCHOOLS_MAP[
+    return (hours) * (60 / SCHOOLS_MAP[school].granularity) + minutes / SCHOOLS_MAP[
         school
     ].granularity
 
@@ -307,7 +307,7 @@ def get_day_to_usage(custom_events, school):
     day_to_usage = {
         # This really should be 24 * 60, but for some reason the timetable is
         # capped at starting at 8am, so 8am-12am is 16 hours.
-        day: [set() for _ in range(int(16 * 60 / SCHOOLS_MAP[school].granularity))]
+        day: [set() for _ in range(int(24 * 60 / SCHOOLS_MAP[school].granularity))]
         for day in ["M", "T", "W", "R", "F", "S", "U"]
     }
 


### PR DESCRIPTION
## Description
Expands the timetable to be 24 hours long (scrollable)
It will scroll down to the first class when the page loads
Also fixes a bug with loading a timetable when a new user views Semester.ly