### PR TITLE
Remove Year Command

### DIFF
--- a/timetable/management/commands/remove_year.py
+++ b/timetable/management/commands/remove_year.py
@@ -9,17 +9,17 @@ from django.core.management.base import BaseCommand
 from django.db.models import Q
 from timetable.models import Semester
 
+
 class Command(BaseCommand):
-    help = 'Delete semester objects for a given year, which deletes all courses, sections, and timetables associated with them.'
+    help = "Delete semester objects for a given year, which deletes all courses, sections, and timetables associated with them."
 
     def add_arguments(self, parser):
-        parser.add_argument('year', type=str)
+        parser.add_argument("year", type=str)
 
     def handle(self, *args, **options):
-        year = options['year']
-        print('Deleting courses, sections, and timetables for year: ', year)
+        year = options["year"]
+        print("Deleting courses, sections, and timetables for year: ", year)
         self.delete_year(year)
-      
+
     def delete_year(self, year):
         Semester.objects.filter(Q(year=year)).delete()
-

--- a/timetable/management/commands/remove_year.py
+++ b/timetable/management/commands/remove_year.py
@@ -1,3 +1,10 @@
+"""
+Deletes Sections, Offerings, and Timetables for a given year. 
+
+Example usage: python manage.py remove_old_courses 2022
+Removes all of the above for the year 2022
+"""
+
 from django.core.management.base import BaseCommand
 from django.db.models import Q
 from timetable.models import Semester

--- a/timetable/management/commands/remove_year.py
+++ b/timetable/management/commands/remove_year.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from timetable.models import Semester
+
+class Command(BaseCommand):
+    help = 'Delete semester objects for a given year, which deletes all courses, sections, and timetables associated with them.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('year', type=str)
+
+    def handle(self, *args, **options):
+        year = options['year']
+        print('Deleting courses, sections, and timetables for year: ', year)
+        self.delete_year(year)
+      
+    def delete_year(self, year):
+        Semester.objects.filter(Q(year=year)).delete()
+


### PR DESCRIPTION
## Description
Command to remove `Semester` objects for a given year, which cascade removes all `Section`, `Offering`, and `Timetable` objects for that given year.


