### PR TITLE
Fix: fork selenium webdriver to make CI work

### DIFF
--- a/.github/workflows/semesterly.yml
+++ b/.github/workflows/semesterly.yml
@@ -66,13 +66,11 @@ jobs:
       - run: npm run test
 
       - name: Run Backend Tests
-        uses: GabrielBB/xvfb-action@v1
         env:
           NODE_ENV: production
           host: jhu.sem.ly
           DB_PORT: ${{ job.services.postgres.ports[5432] }}
-        with:
-          run: python manage.py test
+        run: python manage.py test
 
       - name: Run docs
         run: make html -C docs

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,4 +57,4 @@ sphinx-rtd-theme==0.5.2
 sphinxcontrib-inlinesyntaxhighlight==0.2
 sphinxcontrib-websupport==1.2.4
 supervisor==4.2.2
-webdriver-manager==3.5.2
+semly-webdriver-manager-fork==4.0.1


### PR DESCRIPTION
## Description
### Problem
![image](https://github.com/jhuopensource/semesterly/assets/37493948/95534979-0eb7-49ed-859a-ef9678421aa7)

CI EndToEnd fails because chromedriver installation path has changed for chrome version `>=115`, A [PR](https://github.com/SergeyPirogov/webdriver_manager/issues/617) was merged to address this issue. However, `webdriver-manager` does not have a recent release that contains the update made in this merged PR.

### Solution
Created `semly-webdriver-manager-fork` that builds the most recent `master` branch that contains the fix and use this package for now until the`webdriver-manager`publishes new release.
