### PR TITLE
Hotfix: update parser to add Spring 2024

### DIFF
--- a/build/run_parser.sh
+++ b/build/run_parser.sh
@@ -3,7 +3,7 @@
 echo starting;
 cd /code
 # TODO: No params does not honor active-only semesters, this is hardcoded for now
-python3 manage.py ingest jhu --term Fall --years 2023;
+python3 manage.py ingest jhu --term Spring --years 2024;
 python3 manage.py digest jhu;
 
 # Run all

--- a/parsing/schools/jhu/config.json
+++ b/parsing/schools/jhu/config.json
@@ -13,10 +13,10 @@
     "2020": ["Fall", "Spring"],
     "2021": ["Fall", "Spring"],
     "2022": ["Fall", "Spring"],
-    "2023": ["Fall", "Spring"]
+    "2023": ["Fall", "Spring"],
+    "2024": ["Spring"]
   },
-  "final_exams": {
-  },
+  "final_exams": {},
   "registrar": true,
   "short_course_weeks_limit": 8
 }

--- a/parsing/schools/jhu/courses.py
+++ b/parsing/schools/jhu/courses.py
@@ -231,7 +231,18 @@ class Parser(BaseParser):
         self.verbosity = verbosity
 
         # Default to hardcoded current year.
-        years = {"2023", "2022", "2021", "2020", "2019", "2018", "2017", "2016", "2015"}
+        years = {
+            "2024",
+            "2023",
+            "2022",
+            "2021",
+            "2020",
+            "2019",
+            "2018",
+            "2017",
+            "2016",
+            "2015",
+        }
         terms = {"Spring", "Fall", "Summer", "Intersession"}
 
         years_and_terms = dict_filter_by_dict(


### PR DESCRIPTION
## Description
Spring 2024 course will be available on SIS next week.
This PR updates our course parser that runs daily to fetch and ingest courses for the new semester.

Parser update made according to [this documentation](https://github.com/jhuopensource/semesterly/blob/develop/dev/adding-semesters.md)
