### PR TITLE
Hotfix add fb:app_id meta tag

### DIFF
--- a/agreement/templates/privacypolicy.html
+++ b/agreement/templates/privacypolicy.html
@@ -2,382 +2,698 @@
 <!DOCTYPE html>
 
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1"
+    />
+    <meta
+      name="description"
+      content="{{ course.name }} at {{ school_name }}: {{ course.description }}"
+    />
+    <meta
+      name="author"
+      content="Noah Presler, Rohan Das, Felix Zhu, Max Yeo, Kristin Yim, Sebastian Cabrejos"
+    />
 
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
-	<meta name="description" content="{{ course.name }} at {{ school_name }}: {{ course.description }}">
-	<meta name="author" content="Noah Presler, Rohan Das, Felix Zhu, Max Yeo, Kristin Yim, Sebastian Cabrejos">
+    <!-- Facebook thumbnail info -->
+    <meta
+      property="og:title"
+      content="{{ course.code }} {{ course.name }} | Semester.ly"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Semesterly" />
+    <meta property="og:url" content="http://semester.ly" />
+    <meta property="og:image" content="http://i.imgur.com/Eem4KTj.png" />
+    <meta property="og:description" content="Privacy Policy" />
+    <meta property="fb:admins" content="535129063" />
+    <meta property="fb:app_id" content="580022102164877" />
 
-	<!-- Facebook thumbnail info -->
-	<meta property="og:title" content="{{ course.code }} {{ course.name }} | Semester.ly" />
-	<meta property="og:type" content="website" />
-	<meta property="og:site_name" content="Semesterly" />
-	<meta property="og:url" content="http://semester.ly" />
-	<meta property="og:image" content="http://i.imgur.com/Eem4KTj.png" />
-	<meta property="og:description" content="Privacy Policy" />
-	<meta property="fb:admins" content="535129063" />
+    <title>Privacy Policy | Semester.ly</title>
+    <link
+      rel="shortcut icon"
+      type="image/x-icon"
+      href="{% static 'img/logo2.0-310x310.png' %}"
+    />
 
-	<title>Privacy Policy | Semester.ly</title>
-	<link rel="shortcut icon" type="image/x-icon" href="{% static 'img/logo2.0-310x310.png' %}" />
+    <!-- TODO: For future SWEs, Find the latest CDNs here https://www.bootstrapcdn.com/ -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootswatch@4.5.2/dist/darkly/bootstrap.min.css"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.3/css/fontawesome.min.css"
+      integrity="sha384-wESLQ85D6gbsF459vf1CiZ2+rr+CsxRY0RpiF1tLlQpDnAgg6rwdsUF1+Ics2bni"
+      crossorigin="anonymous"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Palanquin:500|Roboto:100,300,400"
+      rel="stylesheet"
+      type="text/css"
+    />
 
-	<!-- TODO: For future SWEs, Find the latest CDNs here https://www.bootstrapcdn.com/ -->
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@4.5.2/dist/darkly/bootstrap.min.css">
-	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
-		integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-	<link rel="stylesheet"
-		href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.3/css/fontawesome.min.css"
-		integrity="sha384-wESLQ85D6gbsF459vf1CiZ2+rr+CsxRY0RpiF1tLlQpDnAgg6rwdsUF1+Ics2bni" crossorigin="anonymous">
-	<link href="https://fonts.googleapis.com/css?family=Palanquin:500|Roboto:100,300,400" rel="stylesheet"
-		type='text/css'>
+    <!-- Google analytics script -->
+    <script>
+      (function (i, s, o, g, r, a, m) {
+        i["GoogleAnalyticsObject"] = r;
+        (i[r] =
+          i[r] ||
+          function () {
+            (i[r].q = i[r].q || []).push(arguments);
+          }),
+          (i[r].l = 1 * new Date());
+        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m);
+      })(window, document, "script", "//www.google-analytics.com/analytics.js", "ga");
 
-	<!-- Google analytics script -->
-	<script>
-		(function (i, s, o, g, r, a, m) {
-			i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-				(i[r].q = i[r].q || []).push(arguments)
-			}, i[r].l = 1 * new Date(); a = s.createElement(o),
-				m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-		})(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+      ga("create", "UA-68704308-1", "auto");
+      ga("send", "pageview");
+    </script>
 
-		ga('create', 'UA-68704308-1', 'auto');
-		ga('send', 'pageview');
-	</script>
+    <script
+      src="https://kit.fontawesome.com/54815f8287.js"
+      crossorigin="anonymous"
+    ></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="https://malsup.github.io/jquery.cycle2.js"></script>
+    <script type="text/javascript" src="/static/js/course-page.js"></script>
 
-	<script src="https://kit.fontawesome.com/54815f8287.js" crossorigin="anonymous"></script>
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-	<script src="https://malsup.github.io/jquery.cycle2.js"></script>
-	<script type='text/javascript' src='/static/js/course-page.js'></script>
+    <!-- <img class="timer-logo" height=75 src="{% static 'img/logo2.0.png' %}"/> -->
+    <link rel="stylesheet" href="{% static 'css/course-page.css' %}" />
+  </head>
 
-	<!-- <img class="timer-logo" height=75 src="{% static 'img/logo2.0.png' %}"/> -->
-	<link rel="stylesheet" href="{% static 'css/course-page.css' %}">
-</head>
+  <body>
+    <header>
+      <div class="grid cf">
+        <a href="/">
+          <img id="logo" src="/static/img/logo2.0-32x32.png" />
+          <h1>Semester.ly</h1>
+        </a>
+      </div>
+    </header>
+    <div id="page" itemscope itemtype="http://schema.org/Rating">
+      <meta itemprop="worstRating" content="0" />
+      <meta itemprop="bestRating" content="5" />
+      <div id="top-bg"></div>
+      <div id="top" class="grid cf">
+        <div class="card-width">
+          <h1>Privacy Policy | March 8, 2019</h1>
+        </div>
+      </div>
+      <div id="content">
+        <div class="grid cf">
+          <div id="card">
+            <div id="TOC">
+              <ul>
+                <li>
+                  <a href="#purpose-scope-consent"
+                    ><strong><em>Purpose | Scope | Consent</em></strong></a
+                  >
+                </li>
+                <li>
+                  <a href="#information-we-collect-about-you"
+                    ><strong><em>Information We Collect About You</em></strong></a
+                  >
+                </li>
+                <li>
+                  <a href="#how-we-use-information-we-collect-about-you"
+                    ><strong
+                      ><em>How We Use Information We Collect About You</em></strong
+                    ></a
+                  >
+                </li>
+                <li>
+                  <a href="#sharing-information-collected-about-you"
+                    ><strong
+                      ><em>Sharing Information Collected About You</em></strong
+                    ></a
+                  >
+                </li>
+                <li>
+                  <a href="#how-to-delete-your-information"
+                    ><strong><em>How To Delete Your Information</em></strong></a
+                  >
+                </li>
+                <li>
+                  <a href="#thirdparty-websites-and-integrations"
+                    ><strong><em>Third‑Party Websites and Integrations</em></strong></a
+                  >
+                </li>
+                <li>
+                  <a
+                    href="#choices-you-have-about-collection-and-use-of-your-information"
+                    ><strong
+                      ><em
+                        >Choices You Have About Collection And Use Of Your
+                        Information</em
+                      ></strong
+                    ></a
+                  >
+                </li>
+                <li>
+                  <a href="#protection-of-personal-information"
+                    ><strong><em>Protection of Personal Information</em></strong></a
+                  >
+                </li>
+                <li>
+                  <a href="#no-collection-of-information-from-children"
+                    ><strong
+                      ><em>No Collection of Information from Children</em></strong
+                    ></a
+                  >
+                </li>
+                <li>
+                  <a href="#use-of-the-service-while-traveling"
+                    ><strong><em>Use of the Service While Traveling</em></strong></a
+                  >
+                </li>
+                <li>
+                  <a href="#no-rights-of-third-parties"
+                    ><strong><em>No Rights of Third Parties</em></strong></a
+                  >
+                </li>
+                <li>
+                  <a href="#changes-to-this-privacy-policy"
+                    ><strong><em>Changes to This Privacy Policy</em></strong></a
+                  >
+                </li>
+                <li>
+                  <a href="#how-to-contact-us"
+                    ><strong><em>How to Contact Us</em></strong></a
+                  >
+                </li>
+              </ul>
+            </div>
 
-<body>
-	<header>
-		<div class="grid cf">
-			<a href="/">
-				<img id="logo" src="/static/img/logo2.0-32x32.png">
-				<h1>Semester.ly</h1>
-			</a>
-		</div>
-	</header>
-	<div id="page" itemscope itemtype="http://schema.org/Rating">
-		<meta itemprop="worstRating" content="0" />
-		<meta itemprop="bestRating" content="5" />
-		<div id="top-bg"></div>
-		<div id="top" class="grid cf">
-			<div class="card-width">
-				<h1>Privacy Policy | March 8, 2019</h1>
-			</div>
-		</div>
-		<div id="content">
-			<div class="grid cf">
-				<div id="card">
-					<div id="TOC">
-						<ul>
-							<li><a href="#purpose-scope-consent"><strong><em>Purpose | Scope | Consent</em></strong></a>
-							</li>
-							<li><a href="#information-we-collect-about-you"><strong><em>Information We Collect About
-											You</em></strong></a></li>
-							<li><a href="#how-we-use-information-we-collect-about-you"><strong><em>How We Use
-											Information We Collect About You</em></strong></a></li>
-							<li><a href="#sharing-information-collected-about-you"><strong><em>Sharing Information
-											Collected About You</em></strong></a></li>
-							<li><a href="#how-to-delete-your-information"><strong><em>How To Delete Your Information</em></strong></a></li>
-							<li><a href="#thirdparty-websites-and-integrations"><strong><em>Third‑Party Websites and
-											Integrations</em></strong></a></li>
-							<li><a href="#choices-you-have-about-collection-and-use-of-your-information"><strong><em>Choices
-											You Have About Collection And Use Of Your Information</em></strong></a></li>
-							<li><a href="#protection-of-personal-information"><strong><em>Protection of Personal
-											Information</em></strong></a></li>
-							<li><a href="#no-collection-of-information-from-children"><strong><em>No Collection of
-											Information from Children</em></strong></a></li>
-							<li><a href="#use-of-the-service-while-traveling"><strong><em>Use of the Service While
-											Traveling</em></strong></a></li>
-							<li><a href="#no-rights-of-third-parties"><strong><em>No Rights of Third
-											Parties</em></strong></a></li>
-							<li><a href="#changes-to-this-privacy-policy"><strong><em>Changes to This Privacy
-											Policy</em></strong></a></li>
-							<li><a href="#how-to-contact-us"><strong><em>How to Contact Us</em></strong></a></li>
-						</ul>
-					</div>
+            <h1 id="purpose-scope-consent">
+              <strong><em>Purpose | Scope | Consent</em></strong>
+            </h1>
+            <p>
+              <strong
+                >Semester.ly is a social and collaborative course scheduling platform
+                for University students across North America. Since its inception, our
+                platform has</strong
+              >
+              <strong
+                >evolved to offer students a one stop shop for course discovery,
+                schedule creation and social planning - reducing student stress
+                infinitely.</strong
+              >
+            </p>
+            <p>
+              <strong
+                >The all-inclusive scheduler includes features such as advanced search
+                settings based on major requirements, department and</strong
+              >
+              <strong
+                >time. Additionally, students can view the university’s official course
+                ratings, as well as their peer’s course-granular emoji ratings.</strong
+              >
+            </p>
+            <p>
+              <strong
+                >Students are able to create, name, and save multiple timetables, and
+                share</strong
+              >
+              <strong>these timetables via URL or</strong>
+              <strong>Facebook/Google. They can also view which</strong>
+              <strong
+                >courses Facebook/Google friends are considering or have previously
+                taken - a great way for freshman to make</strong
+              >
+              <strong
+                >new friends and for all students to make lasting connections!</strong
+              >
+            </p>
+            <p>
+              <strong
+                >We (“Semester.ly,” “we,” “us,” or “our”) have developed this privacy
+                policy (the “Privacy Policy”) to demonstrate our commitment to
+                protecting your privacy and we encourage you to read it
+                carefully.</strong
+              >
+            </p>
+            <p>
+              <strong
+                >The Privacy Policy is intended to describe for you, as an individual
+                who is (1) a visitor, user or customer of a website or web presence
+                owned or operated by Semester.ly, and/or (2) a user of the Semester.ly
+                secure platform and communications service (collectively, the
+                “Service”), the information we collect, how that information may be
+                used, with whom it may be shared, and your choices about such uses and
+                disclosures.</strong
+              >
+            </p>
+            <p>
+              <strong
+                >By visiting the Site or using the Service, you are consenting to the
+                practices described in this Privacy Policy.</strong
+              >
+            </p>
+            <h1 id="information-we-collect-about-you">
+              <strong><em>Information We Collect About You</em></strong>
+            </h1>
+            <p>
+              We use various technologies to collect information from your computer or
+              other internet access device related to your use of the Service.
+            </p>
+            <p>
+              Our website (https://semester.ly) captures e‑mail addresses, mobile phone
+              numbers, and other log‑in information from visitors who opt‑in by
+              providing their email address, mobile phone numbers and/or log‑in
+              information. It also captures non‑personally‑identifiable information for
+              purposes of analytics that assess visitor trends, such as numbers of
+              users, pages visited, and IP address country of origin.
+            </p>
+            <p>
+              Our encrypted invite system website (https://semester.ly) captures user IP
+              addresses to prevent misuse of our system and to enforce sender‑specified
+              message restrictions. It also collects user and device information for,
+              among other things, authentication and system integrity. In addition, we
+              collect date/time information and recipient service links (<em>e.g.</em>,
+              user identifier associated with a particular type of application). For
+              purposes of facilitating the transmission of user messages on the Service,
+              Semester.ly will rely on specific contact information that users provide
+              (<em>e.g.</em>, an e‑mail address for a message recipient). Semester.ly
+              does not collect any other information from users’ contact lists or
+              devices.
+            </p>
+            <p>
+              Our platform (https://semester.ly) collects additional information
+              necessary to provide the Semester.ly service. This information include IP
+              addresses to prevent misuse of our system and to enforce sender‑specified
+              message restrictions. It also includes user‑specific device information
+              and, if the user opts in, may collect the email addresses, SMS addresses,
+              University specific log-in credentials, and/or Facebook/Google accounts
+              associated with the user’s Semester.ly account.
+            </p>
+            <p>
+              We use google analytics to collect basic, anonymous information about our
+              users for aggregate analysis, traffic monitoring, and growth metrics.
+              (Information about Google Analytics usage of data and privacy policies can
+              be found here).
+            </p>
+            <h4 id="non-registered-logged-out-users">
+              <strong>Non-Registered &amp; Logged Out Users</strong>
+            </h4>
+            <p>
+              Outside of the use of Google Analytics, for non-registered/logged out
+              users we exclusively collect completely anonymous data.
+            </p>
+            <p>
+              1. When a user in this category creates a schedule or executes a search we
+              log this information. We simply log that it occurred, when it occurred,
+              and what results/courses were returned/added. There is
+              <em>no link to the user</em>, no information like IP address or cookies
+              are attached to these logs.
+            </p>
+            <p>
+              <em>2.</em> <em>In the future</em>, we will add other trivial logs
+              <em>anonymous</em> for analytics purposes.
+            </p>
+            <p>
+              3. When a user creates a timetable or sets certain preferences (e.g.
+              conflicts allowed in schedule) we store this information locally on the
+              user’s browser. It remains on their device exclusively so that it can be
+              loaded when they return to the site.
+            </p>
+            <p>
+              4. We use cookies to understand and save user’s preferences for future
+              visits.
+            </p>
+            <h4 id="registered-logged-in-user-no-permissions">
+              <strong>Registered &amp; Logged in User – No Permissions</strong>
+            </h4>
+            <p>
+              When a user is logged in (and therefore registered), but has not enabled
+              any permissions we store the following information about the student (some
+              info drawn from Facebook/Google API which the user has logged in with and
+              approved):
+            </p>
+            <p>1. Name (Facebook/Google API)</p>
+            <p>2. Email (Facebook/Google API)</p>
+            <p>4. Class Year</p>
+            <p>5. Major</p>
+            <p>6. Profile Picture (Facebook/Google API)</p>
+            <p>7. The school they are using Semester.ly with</p>
+            <p>
+              If a user creates a timetable/schedule we store that (including courses,
+              name, semester, time last updated) and link that to the user.
+            </p>
+            <p>
+              If a user reviews a course with an emoji, we store that information as
+              well. It is never displayed to any other user.
+            </p>
+            <p>
+              If a user enables notifications, we store an encrypted token from
+              Google/Firebase Cloud Messaging in order to send these push messages.
+            </p>
+            <p>
+              No user data is ever shared to any other user in this state. Only the
+              logged in user can view their information/reviews, change their settings,
+              and access their timetables.
+            </p>
+            <p>
+              We maintain the capability to view the user’s list of friends through the
+              Facebook/Google API
+            </p>
+            <h4 id="registered-logged-in-user-social-course-permission-enabled">
+              <strong
+                >Registered &amp; Logged in User – Social Course Permission
+                Enabled</strong
+              >
+            </h4>
+            <p>
+              In this state, the user has all that the previous state does with
+              additional features/exposures of data.
+            </p>
+            <p>
+              Users with social course permission enabled can see which of their
+              Facebook friends are in the courses indicated through use of the
+              Semester.ly platform, and in return friends can see that they are in the
+              course as well. <em>This feature works only for Facebook</em>/Google
+              <em>Friends</em> – if the two students are not officially friends
+              according to the Facebook/Google official API, this relationship is not
+              exposed.
+            </p>
+            <p>
+              The exact time a user is taking the course is not exposed – only that they
+              are taking the course.
+            </p>
+            <p>
+              The user’s social graph is never exposed in any other form to any other
+              user.
+            </p>
+            <h4
+              id="registered-logged-in-user-social-course-social-sections-permission-enabled"
+            >
+              <strong
+                >Registered &amp; Logged in User – Social Course &amp; Social Sections
+                Permission Enabled</strong
+              >
+            </h4>
+            <p>
+              Users with this additional “Social Sections” permission can see not only
+              which courses their friends are taking but what times (called sections)
+              they are taking them. By enabling this, they expose the same information
+              about themselves to their Facebook/Google friends.
+            </p>
+            <h4 id="registered-logged-in-user-fully-public-permissions">
+              <strong
+                >Registered &amp; Logged in User – Fully Public Permissions</strong
+              >
+            </h4>
+            <p>
+              In this case a user let’s any other Semester.ly user at their school to
+              see their courses and sections. This requires that all previously stated
+              permissions be enabled.
+            </p>
+            <p>
+              Users in this state can see other users in the same state which are taking
+              similar course loads and can then connect, communicate, and collaborate.
+            </p>
+            <p>
+              The only information exposed is the courses and course sections these
+              users are taking and links to their <em>public facing</em> Facebook/Google
+              profiles as shown below.
+            </p>
+            <p><strong>Google Connected Users – Opt-in Calendar Usage</strong></p>
+            <p>
+              Google connected users provide Semester.ly with access to their Google
+              Calendars via the Google Calendar API. When opted for, Semester.ly can and
+              may create new calendars and events for the user representing information
+              the user has entered via the Semester.ly application.
+            </p>
+            <p>
+              If the user opts in, Semester.ly can and may use the previously stated
+              Google Calendar API to access information about the user’s daily free/busy
+              intervals. No event names are ever shared with other users. Free/busy
+              information alone will be shared only with the user’s explicit permission
+              to other users who the calendar owner has explicitly indicated, chosen, or
+              shared the link with.
+            </p>
+            <p>
+              Semester.ly may use the user’s google calendar information for internal
+              analytics but no information will be shared with any other user or third
+              party without explicit permission
+            </p>
+            <p>
+              <strong
+                >Johns Hopkins University Student Information Systems (SIS) Connected
+                Users - Opt-in Data Import</strong
+              >
+            </p>
+            <p>
+              Student Information Systems (SIS) connected users provide Semester.ly with
+              access to their SIS data. When opted in, Semester.ly can pull users' year,
+              major, and course history in the form of course codes and year/term the
+              course was taken. This information will help Semester.ly tailor course
+              results, check pre-requisites, offer degree planning tips, and gather
+              course reviews. This will be done at both a personal and aggregate level.
+              Individual data will be checked against a database of popular classes and
+              sequences for certain degrees in order to give users tailored search
+              results and recommendations. Aggregated data will be used to create this
+              database and no personal identifiers will be tied to any analysis. This is
+              the full extent of any data collection and usage and will be updated for
+              any future changes. Semester.ly will never pull any sensitive information
+              like student standing or financials. Personal data will never be viewed by
+              JHU IT personnel or Semester.ly team members. Users always have the option
+              to opt-out of this feature and/or delete their account if these terms are
+              unsatisfactory.
+            </p>
+            <h1 id="how-we-use-information-we-collect-about-you">
+              <strong><em>How We Use Information We Collect About You</em></strong>
+            </h1>
+            <p>
+              The information collected from our website will be used for standard,
+              non‑invasive, non‑personally‑identifiable visitor trend analytics, simply
+              to help us measure how users interact with our website content.
+            </p>
+            <p>
+              With regard to the Semester.ly app/SaaS, the Service’s end‑to‑end
+              encryption prevents us from accessing user‑specific content.
+            </p>
+            <p>
+              As noted above, we capture user IP addresses to prevent misuse of our
+              system and to enforce sender‑specified message restrictions, and user and
+              device information for, among other things, authentication and system
+              integrity.
+            </p>
 
-					<h1 id="purpose-scope-consent"><strong><em>Purpose | Scope | Consent</em></strong></h1>
-					<p><strong>Semester.ly is a social and collaborative course scheduling platform for University
-							students across North America. Since its inception, our platform has</strong>
-						<strong>evolved to offer students a one stop shop for course discovery, schedule creation and
-							social planning - reducing student stress infinitely.</strong></p>
-					<p><strong>The all-inclusive scheduler includes features such as advanced search settings based on
-							major requirements, department and</strong> <strong>time. Additionally, students can view
-							the university’s official course ratings, as well as their peer’s course-granular emoji
-							ratings.</strong></p>
-					<p><strong>Students are able to create, name, and save multiple timetables, and share</strong>
-						<strong>these timetables via URL or</strong> <strong>Facebook/Google. They can also view
-							which</strong> <strong>courses Facebook/Google friends are considering or have previously
-							taken - a great way for freshman to make</strong> <strong>new friends and for all students
-							to make lasting connections!</strong></p>
-					<p><strong>We (“Semester.ly,” “we,” “us,” or “our”) have developed this privacy policy (the “Privacy
-							Policy”) to demonstrate our commitment to protecting your privacy and we encourage you to
-							read it carefully.</strong></p>
-					<p><strong>The Privacy Policy is intended to describe for you, as an individual who is (1) a
-							visitor, user or customer of a website or web presence owned or operated by Semester.ly,
-							and/or (2) a user of the Semester.ly secure platform and communications service
-							(collectively, the “Service”), the information we collect, how that information may be used,
-							with whom it may be shared, and your choices about such uses and disclosures.</strong></p>
-					<p><strong>By visiting the Site or using the Service, you are consenting to the practices described
-							in this Privacy Policy.</strong></p>
-					<h1 id="information-we-collect-about-you"><strong><em>Information We Collect About You</em></strong>
-					</h1>
-					<p>We use various technologies to collect information from your computer or other internet access
-						device related to your use of the Service.</p>
-					<p>Our website (https://semester.ly) captures e‑mail addresses, mobile phone numbers, and other
-						log‑in information from visitors who opt‑in by providing their email address, mobile phone
-						numbers and/or log‑in information. It also captures non‑personally‑identifiable information for
-						purposes of analytics that assess visitor trends, such as numbers of users, pages visited, and
-						IP address country of origin.</p>
-					<p>Our encrypted invite system website (https://semester.ly) captures user IP addresses to prevent
-						misuse of our system and to enforce sender‑specified message restrictions. It also collects user
-						and device information for, among other things, authentication and system integrity. In
-						addition, we collect date/time information and recipient service links (<em>e.g.</em>, user
-						identifier associated with a particular type of application). For purposes of facilitating the
-						transmission of user messages on the Service, Semester.ly will rely on specific contact
-						information that users provide (<em>e.g.</em>, an e‑mail address for a message recipient).
-						Semester.ly does not collect any other information from users’ contact lists or devices.</p>
-					<p>Our platform (https://semester.ly) collects additional information necessary to provide the
-						Semester.ly service. This information include IP addresses to prevent misuse of our system and
-						to enforce sender‑specified message restrictions. It also includes user‑specific device
-						information and, if the user opts in, may collect the email addresses, SMS addresses, University
-						specific log-in credentials, and/or Facebook/Google accounts associated with the user’s
-						Semester.ly account.</p>
-					<p>We use google analytics to collect basic, anonymous information about our users for aggregate
-						analysis, traffic monitoring, and growth metrics. (Information about Google Analytics usage of
-						data and privacy policies can be found here).</p>
-					<h4 id="non-registered-logged-out-users"><strong>Non-Registered &amp; Logged Out Users</strong></h4>
-					<p>Outside of the use of Google Analytics, for non-registered/logged out users we exclusively
-						collect completely anonymous data.</p>
-					<p>1. When a user in this category creates a schedule or executes a search we log this information.
-						We simply log that it occurred, when it occurred, and what results/courses were returned/added.
-						There is <em>no link to the user</em>, no information like IP address or cookies are attached to
-						these logs.</p>
-					<p><em>2.</em> <em>In the future</em>, we will add other trivial logs <em>anonymous</em> for
-						analytics purposes.</p>
-					<p>3. When a user creates a timetable or sets certain preferences (e.g. conflicts allowed in
-						schedule) we store this information locally on the user’s browser. It remains on their device
-						exclusively so that it can be loaded when they return to the site.</p>
-					<p>4. We use cookies to understand and save user’s preferences for future visits.</p>
-					<h4 id="registered-logged-in-user-no-permissions"><strong>Registered &amp; Logged in User – No
-							Permissions</strong></h4>
-					<p>When a user is logged in (and therefore registered), but has not enabled any permissions we store
-						the following information about the student (some info drawn from Facebook/Google API which the
-						user has logged in with and approved):</p>
-					<p>1. Name (Facebook/Google API)</p>
-					<p>2. Email (Facebook/Google API)</p>
-					<p>4. Class Year</p>
-					<p>5. Major</p>
-					<p>6. Profile Picture (Facebook/Google API)</p>
-					<p>7. The school they are using Semester.ly with</p>
-					<p>If a user creates a timetable/schedule we store that (including courses, name, semester, time
-						last updated) and link that to the user.</p>
-					<p>If a user reviews a course with an emoji, we store that information as well. It is never
-						displayed to any other user.</p>
-					<p>If a user enables notifications, we store an encrypted token from Google/Firebase Cloud Messaging
-						in order to send these push messages.</p>
-					<p>No user data is ever shared to any other user in this state. Only the logged in user can view
-						their information/reviews, change their settings, and access their timetables.</p>
-					<p>We maintain the capability to view the user’s list of friends through the Facebook/Google API</p>
-					<h4 id="registered-logged-in-user-social-course-permission-enabled"><strong>Registered &amp; Logged
-							in User – Social Course Permission Enabled</strong></h4>
-					<p>In this state, the user has all that the previous state does with additional features/exposures
-						of data.</p>
-					<p>Users with social course permission enabled can see which of their Facebook friends are in the
-						courses indicated through use of the Semester.ly platform, and in return friends can see that
-						they are in the course as well. <em>This feature works only for Facebook</em>/Google
-						<em>Friends</em> – if the two students are not officially friends according to the
-						Facebook/Google official API, this relationship is not exposed.</p>
-					<p>The exact time a user is taking the course is not exposed – only that they are taking the course.
-					</p>
-					<p>The user’s social graph is never exposed in any other form to any other user.</p>
-					<h4 id="registered-logged-in-user-social-course-social-sections-permission-enabled">
-						<strong>Registered &amp; Logged in User – Social Course &amp; Social Sections Permission
-							Enabled</strong></h4>
-					<p>Users with this additional “Social Sections” permission can see not only which courses their
-						friends are taking but what times (called sections) they are taking them. By enabling this, they
-						expose the same information about themselves to their Facebook/Google friends.</p>
-					<h4 id="registered-logged-in-user-fully-public-permissions"><strong>Registered &amp; Logged in User
-							– Fully Public Permissions</strong></h4>
-					<p>In this case a user let’s any other Semester.ly user at their school to see their courses and
-						sections. This requires that all previously stated permissions be enabled.</p>
-					<p>Users in this state can see other users in the same state which are taking similar course loads
-						and can then connect, communicate, and collaborate.</p>
-					<p>The only information exposed is the courses and course sections these users are taking and links
-						to their <em>public facing</em> Facebook/Google profiles as shown below.</p>
-					<p><strong>Google Connected Users – Opt-in Calendar Usage</strong></p>
-					<p>Google connected users provide Semester.ly with access to their Google Calendars via the Google
-						Calendar API. When opted for, Semester.ly can and may create new calendars and events for the
-						user representing information the user has entered via the Semester.ly application.</p>
-					<p>If the user opts in, Semester.ly can and may use the previously stated Google Calendar API to
-						access information about the user’s daily free/busy intervals. No event names are ever shared
-						with other users. Free/busy information alone will be shared only with the user’s explicit
-						permission to other users who the calendar owner has explicitly indicated, chosen, or shared the
-						link with.</p>
-					<p>Semester.ly may use the user’s google calendar information for internal analytics but no
-						information will be shared with any other user or third party without explicit permission</p>
-					<p><strong>Johns Hopkins University Student Information Systems (SIS) Connected Users - Opt-in Data
-							Import</strong></p>
-					<p>Student Information Systems (SIS) connected users provide Semester.ly with access to their SIS
-						data. When opted in, Semester.ly can pull users' year, major, and course history in the form of
-						course codes and year/term the course was taken. This information will help Semester.ly tailor
-						course results, check pre-requisites, offer degree planning tips, and gather course reviews.
-						This will be done at both a personal and aggregate level. Individual data will be checked
-						against a database of popular classes and sequences for certain degrees in order to give users
-						tailored search results and recommendations. Aggregated data will be used to create this
-						database and no personal identifiers will be tied to any analysis. This is the full extent of
-						any data collection and usage and will be updated for any future changes. Semester.ly will never
-						pull any sensitive information like student standing or financials. Personal data will never be
-						viewed by JHU IT personnel or Semester.ly team members. Users always have the option to opt-out
-						of this feature and/or delete their account if these terms are unsatisfactory.</p>
-					<h1 id="how-we-use-information-we-collect-about-you"><strong><em>How We Use Information We Collect
-								About You</em></strong></h1>
-					<p>The information collected from our website will be used for standard, non‑invasive,
-						non‑personally‑identifiable visitor trend analytics, simply to help us measure how users
-						interact with our website content.</p>
-					<p>With regard to the Semester.ly app/SaaS, the Service’s end‑to‑end encryption prevents us from
-						accessing user‑specific content.</p>
-					<p>As noted above, we capture user IP addresses to prevent misuse of our system and to enforce
-						sender‑specified message restrictions, and user and device information for, among other things,
-						authentication and system integrity.</p>
+            <h1 id="sharing-information-collected-about-you">
+              <strong><em>Sharing Information Collected About You</em></strong>
+            </h1>
+            <p>
+              Website opt‑in e‑mail capture is the only type of information that could
+              be shared with third parties for internal marketing purposes. Platform
+              service links will only be used (outside of the Service operation) to
+              inform of service failures, emergencies, verification of account changes
+              (such as new devices or password changes), or similar purposes.
+            </p>
+            <p>
+              Semester.ly is deeply committed to protecting your personal information.
+              To the extent we disclose personal information to a third party, they may
+              have their own privacy policies which describe how they use and disclose
+              personal information. Those policies will govern use, handling and
+              disclosure of your personal information once we have shared it with those
+              third parties as described in this Privacy Policy.
+            </p>
+            <p>
+              We do not sell, trade, or otherwise transfer to outside parties your
+              personally identifiable information unless we provide users with advance
+              notice. This does not include website hosting partners and other parties
+              who assist us in operating our website, conducting our business, or
+              serving our users, so long as those parties agree to keep this information
+              confidential. We may also release information when it’s release is
+              appropriate to comply with the law, enforce our site policies, or protect
+              ours or others’ rights, property or safety.
+            </p>
+            <p>
+              We may also disclose your information in response to a subpoena or similar
+              investigative demand, a court order, or a request for cooperation from law
+              enforcement or other government agency; to establish or exercise our legal
+              rights; to defend against legal claims; or as otherwise required by law.
+              Any information shared in such a case would be shared in the format in
+              which Semester.ly maintains it (<em>e.g.</em>, end‑to‑end encrypted
+              content, which would require an end user’s device to decrypt). However,
+              only content is encrypted, whereas metadata, which might also need to be
+              disclosed, is not. In such cases, we may raise or waive any legal
+              objection or right available to us, in our sole discretion. We may also
+              disclose your information when we believe it is appropriate in connection
+              with efforts to investigate, prevent, report or take other action
+              regarding illegal activity, suspected fraud or other wrongdoing; to
+              protect and defend the rights, property or safety of you, Semester.ly, our
+              employees, or the public; to comply with applicable law or cooperate with
+              law enforcement; or to enforce our terms and conditions or other
+              agreements or policies. Likewise, we may disclose your information in
+              connection with a substantial corporate transaction, such as a merger,
+              consolidation, or asset sale, or in the unlikely event of bankruptcy.
+            </p>
 
-					<h1 id="sharing-information-collected-about-you"><strong><em>Sharing Information Collected About
-								You</em></strong></h1>
-					<p>Website opt‑in e‑mail capture is the only type of information that could be shared with third
-						parties for internal marketing purposes. Platform service links will only be used (outside of
-						the Service operation) to inform of service failures, emergencies, verification of account
-						changes (such as new devices or password changes), or similar purposes.</p>
-					<p>Semester.ly is deeply committed to protecting your personal information. To the extent we
-						disclose personal information to a third party, they may have their own privacy policies which
-						describe how they use and disclose personal information. Those policies will govern use,
-						handling and disclosure of your personal information once we have shared it with those third
-						parties as described in this Privacy Policy.</p>
-					<p>We do not sell, trade, or otherwise transfer to outside parties your personally identifiable
-						information unless we provide users with advance notice. This does not include website hosting
-						partners and other parties who assist us in operating our website, conducting our business, or
-						serving our users, so long as those parties agree to keep this information confidential. We may
-						also release information when it’s release is appropriate to comply with the law, enforce our
-						site policies, or protect ours or others’ rights, property or safety.</p>
-					<p>We may also disclose your information in response to a subpoena or similar investigative demand,
-						a court order, or a request for cooperation from law enforcement or other government agency; to
-						establish or exercise our legal rights; to defend against legal claims; or as otherwise required
-						by law. Any information shared in such a case would be shared in the format in which Semester.ly
-						maintains it (<em>e.g.</em>, end‑to‑end encrypted content, which would require an end user’s
-						device to decrypt). However, only content is encrypted, whereas metadata, which might also need
-						to be disclosed, is not. In such cases, we may raise or waive any legal objection or right
-						available to us, in our sole discretion. We may also disclose your information when we believe
-						it is appropriate in connection with efforts to investigate, prevent, report or take other
-						action regarding illegal activity, suspected fraud or other wrongdoing; to protect and defend
-						the rights, property or safety of you, Semester.ly, our employees, or the public; to comply with
-						applicable law or cooperate with law enforcement; or to enforce our terms and conditions or
-						other agreements or policies. Likewise, we may disclose your information in connection with a
-						substantial corporate transaction, such as a merger, consolidation, or asset sale, or in the
-						unlikely event of bankruptcy.</p>
+            <h1 id="how-to-delete-your-information">
+              <strong><em>How To Delete Your Information</em></strong>
+            </h1>
+            <p>
+              No information is stored in our server if you choose to not log in. If you
+              are logged in with any provider and wants your information deleted, simply
+              open the user profile page located at the top right and click on "Delete
+              my account and all related information".
+            </p>
 
-					<h1 id="how-to-delete-your-information"><strong><em>How To Delete Your Information</em></strong></h1>
-					<p>No information is stored in our server if you choose to not log in. If you are logged in with any
-						provider and wants your information deleted, simply open the user profile page located at the top right
-						and click on "Delete my account and all related information".
-					</p>
+            <h1 id="thirdparty-websites-and-integrations">
+              <strong><em>Third‑Party Websites and Integrations</em></strong>
+            </h1>
+            <p>
+              All third‑party integrations (including, but not limited to, social media)
+              are subject to privacy and security vulnerabilities. Content sent through
+              such services (<em>i.e.</em>, “out of band” from the Semester.ly service)
+              is frequently insecure.
+            </p>
+            <p>
+              There may be places on the Service where you may click on a link to access
+              other websites or services that do not operate under this Privacy Policy.
+              In addition, you may be logged into a third party website, such as a
+              payment processing site or social media site, while using the Service.
+              These third‑party websites may independently solicit and collect
+              information, including personal information, from you and, in some
+              instances, provide us with information about your activities on those
+              websites. We recommend that you consult the privacy statements of all
+              third‑party websites you visit by clicking on the “privacy” link typically
+              located at the bottom of the webpage you are visiting.
+            </p>
 
-					<h1 id="thirdparty-websites-and-integrations"><strong><em>Third‑Party Websites and
-								Integrations</em></strong></h1>
-					<p>All third‑party integrations (including, but not limited to, social media) are subject to privacy
-						and security vulnerabilities. Content sent through such services (<em>i.e.</em>, “out of band”
-						from the Semester.ly service) is frequently insecure.</p>
-					<p>There may be places on the Service where you may click on a link to access other websites or
-						services that do not operate under this Privacy Policy. In addition, you may be logged into a
-						third party website, such as a payment processing site or social media site, while using the
-						Service. These third‑party websites may independently solicit and collect information, including
-						personal information, from you and, in some instances, provide us with information about your
-						activities on those websites. We recommend that you consult the privacy statements of all
-						third‑party websites you visit by clicking on the “privacy” link typically located at the bottom
-						of the webpage you are visiting.</p>
+            <h1 id="choices-you-have-about-collection-and-use-of-your-information">
+              <strong
+                ><em
+                  >Choices You Have About Collection And Use Of Your Information</em
+                ></strong
+              >
+            </h1>
+            <p>
+              You can choose not to provide us with certain information, but that may
+              result in you being unable to use certain features of the Service because
+              such information may be required in order to validate your identity,
+              utilize the Service, or to contact us for information. Further you can
+              choose certain levels of permission, as discussed above.
+            </p>
+            <p>
+              All non‑authentication or network communication use of our Service is
+              opt‑in. The system at launch begins as “anonymous”. As users add in
+              service links, they must confirm that they want the service being added to
+              their account by visiting a link e‑mailed or texted to them (Facebook or
+              Google are OAuth presentations).
+            </p>
+            <p>
+              When you contact us through the Service, your account will be set up to
+              receive e‑mail messages unless you indicate that you do not wish to
+              receive e‑mails. At any time, you can choose to stop receiving such
+              e‑mails by following the instructions found in the e‑mails.
+            </p>
+            <p>
+              All facets of the Service are opt‑in and users are free to annihilate any
+              of their data stored by our system, except for access logs, which will be
+              purged periodically. As of March 8th, 2019, users can delete their
+              accounts through the Account Settings portal.
+            </p>
+            <h1 id="protection-of-personal-information">
+              <strong><em>Protection of Personal Information</em></strong>
+            </h1>
+            <p>
+              We take appropriate security measures to help safeguard your personal
+              information from unauthorized access and disclosure.
+            </p>
+            <p>
+              We want you to feel confident using the Service; however, no system can
+              guarantee absolute security. Therefore, it is important for you to protect
+              against unauthorized access to your password and to your computer or other
+              internet access device. In addition, it is recommended that you do not
+              send personal health or other sensitive information to Semester.ly or
+              anyone else using unsecured means. Should you choose to supply
+              confidential information in this manner, you do so at your own risk.
+            </p>
+            <p>
+              Although we take steps to secure your information, we do not guarantee the
+              security of your information, and you should not expect that your personal
+              information, searches, or other communications will always remain secure.
+              Please refer to the Federal Trade Commission’s website at
+              http://www.consumer.ftc.gov for information about how to protect yourself
+              against identity theft.
+            </p>
 
-					<h1 id="choices-you-have-about-collection-and-use-of-your-information"><strong><em>Choices You Have
-								About Collection And Use Of Your Information</em></strong></h1>
-					<p>You can choose not to provide us with certain information, but that may result in you being
-						unable to use certain features of the Service because such information may be required in order
-						to validate your identity, utilize the Service, or to contact us for information. Further you
-						can choose certain levels of permission, as discussed above.</p>
-					<p>All non‑authentication or network communication use of our Service is opt‑in. The system at
-						launch begins as “anonymous”. As users add in service links, they must confirm that they want
-						the service being added to their account by visiting a link e‑mailed or texted to them (Facebook
-						or Google are OAuth presentations).</p>
-					<p>When you contact us through the Service, your account will be set up to receive e‑mail messages
-						unless you indicate that you do not wish to receive e‑mails. At any time, you can choose to stop
-						receiving such e‑mails by following the instructions found in the e‑mails.</p>
-					<p>All facets of the Service are opt‑in and users are free to annihilate any of their data stored by
-						our system, except for access logs, which will be purged periodically. As of March 8th, 2019,
-						users can delete their accounts through the Account Settings portal.</p>
-					<h1 id="protection-of-personal-information"><strong><em>Protection of Personal
-								Information</em></strong></h1>
-					<p>We take appropriate security measures to help safeguard your personal information from
-						unauthorized access and disclosure.</p>
-					<p>We want you to feel confident using the Service; however, no system can guarantee absolute
-						security. Therefore, it is important for you to protect against unauthorized access to your
-						password and to your computer or other internet access device. In addition, it is recommended
-						that you do not send personal health or other sensitive information to Semester.ly or anyone
-						else using unsecured means. Should you choose to supply confidential information in this manner,
-						you do so at your own risk.</p>
-					<p>Although we take steps to secure your information, we do not guarantee the security of your
-						information, and you should not expect that your personal information, searches, or other
-						communications will always remain secure. Please refer to the Federal Trade Commission’s website
-						at http://www.consumer.ftc.gov for information about how to protect yourself against identity
-						theft.</p>
+            <h1 id="no-collection-of-information-from-children">
+              <strong><em>No Collection of Information from Children</em></strong>
+            </h1>
+            <p>
+              The Service is intended for use by adults only. Semester.ly does not
+              solicit or knowingly collect any information from visitors under 18 years
+              of age. Please do not use the Service if you are not yet 18.
+            </p>
 
-					<h1 id="no-collection-of-information-from-children"><strong><em>No Collection of Information from
-								Children</em></strong></h1>
-					<p>The Service is intended for use by adults only. Semester.ly does not solicit or knowingly collect
-						any information from visitors under 18 years of age. Please do not use the Service if you are
-						not yet 18.</p>
+            <h1 id="use-of-the-service-while-traveling">
+              <strong><em>Use of the Service While Traveling</em></strong>
+            </h1>
+            <p>
+              This Privacy Policy is intended to cover collection of information via the
+              Service from residents of the United States and Canada (collectively, the
+              “Intended Countries”). If you are using the Service from outside the
+              Intended Countries, please be aware that your information may be
+              transferred to, stored, and processed in the United States where our
+              servers are located and our central database is operated. By using the
+              Service, you understand that your information may be transferred to our
+              facilities and those third parties with whom we share it as described in
+              this privacy policy.
+            </p>
 
-					<h1 id="use-of-the-service-while-traveling"><strong><em>Use of the Service While
-								Traveling</em></strong></h1>
-					<p>This Privacy Policy is intended to cover collection of information via the Service from residents
-						of the United States and Canada (collectively, the “Intended Countries”). If you are using the
-						Service from outside the Intended Countries, please be aware that your information may be
-						transferred to, stored, and processed in the United States where our servers are located and our
-						central database is operated. By using the Service, you understand that your information may be
-						transferred to our facilities and those third parties with whom we share it as described in this
-						privacy policy.</p>
+            <h1 id="no-rights-of-third-parties">
+              <strong><em>No Rights of Third Parties</em></strong>
+            </h1>
+            <p>
+              This Privacy Policy does not create rights enforceable by third parties or
+              require disclosure of any personal information relating to users.
+            </p>
 
-					<h1 id="no-rights-of-third-parties"><strong><em>No Rights of Third Parties</em></strong></h1>
-					<p>This Privacy Policy does not create rights enforceable by third parties or require disclosure of
-						any personal information relating to users.</p>
+            <h1 id="changes-to-this-privacy-policy">
+              <strong><em>Changes to This Privacy Policy</em></strong>
+            </h1>
+            <p>
+              We will occasionally update this Privacy Policy to reflect changes in our
+              practices and services. When we post changes to this Privacy Policy, we
+              will revise the date at the top of this Privacy Policy.
+            </p>
+            <p>
+              If we make any material changes in the way we collect, use, and/or share
+              your personal information, we will notify you by sending an e‑mail to the
+              e‑mail address you most recently provided us in your account, profile, or
+              registration (unless we do not have such an e‑mail address), and/or by
+              prominently posting notice of the changes on the Website. We recommend
+              that you check the Website from time to time to inform yourself of any
+              changes in this Privacy Policy or any of our other policies.
+            </p>
+            <h1 id="how-to-contact-us">
+              <strong><em>How to Contact Us</em></strong>
+            </h1>
+            <p>
+              If you have any questions about this Privacy Policy or our
+              information‑handling practices, or if you would like to request
+              information about our disclosure of personal information to third parties,
+              please contact us by e‑mail at
+              <a href="mailto:semesterly@jhu.edu">semesterly@jhu.edu</a>.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
 
-					<h1 id="changes-to-this-privacy-policy"><strong><em>Changes to This Privacy Policy</em></strong>
-					</h1>
-					<p>We will occasionally update this Privacy Policy to reflect changes in our practices and services.
-						When we post changes to this Privacy Policy, we will revise the date at the top of this Privacy
-						Policy.</p>
-					<p>If we make any material changes in the way we collect, use, and/or share your personal
-						information, we will notify you by sending an e‑mail to the e‑mail address you most recently
-						provided us in your account, profile, or registration (unless we do not have such an e‑mail
-						address), and/or by prominently posting notice of the changes on the Website. We recommend that
-						you check the Website from time to time to inform yourself of any changes in this Privacy Policy
-						or any of our other policies.</p>
-					<h1 id="how-to-contact-us"><strong><em>How to Contact Us</em></strong></h1>
-					<p>If you have any questions about this Privacy Policy or our information‑handling practices, or if
-						you would like to request information about our disclosure of personal information to third
-						parties, please contact us by e‑mail at <a
-							href="mailto:semesterly@jhu.edu">semesterly@jhu.edu</a>.</p>
-
-				</div>
-			</div>
-		</div>
-	</div>
-
-	<footer>
-
-	</footer>
-</body>
-
+    <footer></footer>
+  </body>
 </html>

--- a/agreement/templates/termsofservice.html
+++ b/agreement/templates/termsofservice.html
@@ -17,6 +17,8 @@
 	<meta property="og:image" content="http://i.imgur.com/Eem4KTj.png" />
 	<meta property="og:description" content="Terms of Service" />
 	<meta property="fb:admins" content="535129063" />
+	<meta property="fb:app_id" content="580022102164877" />
+
 
 	<title>Terms of Service | Semester.ly</title>
 	<link rel="shortcut icon" type="image/x-icon" href="{% static 'img/logo2.0-310x310.png' %}" />


### PR DESCRIPTION
## Description
Meta is not able to pick up our privacy policy because it is missing a tag `fb:app_id`, causing an alarm in meta developer portal. 
This PR adds the tag to avoid being suspended from facebook API access

![image](https://github.com/jhuopensource/semesterly/assets/37493948/ca02f3a0-ee60-48ad-b79d-a2ba4accce0d)

