### PR TITLE
Evaluations: Add evaluation parsing script and the resultant JSON file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ node_modules
 npm-debug.log.*
 openssl.cnf
 parse_errors.log
-parsing/**/data/*.json
+parsing/**/data/courses.json
 parsing/**/logs/*.json
 parsing/**/logs/*.log
 *.pid

--- a/build/run_parser.sh
+++ b/build/run_parser.sh
@@ -5,6 +5,7 @@ cd /code
 # TODO: No params does not honor active-only semesters, this is hardcoded for now
 python3 manage.py ingest jhu --term Spring --years 2024;
 python3 manage.py digest jhu;
+python3 manage.py digest jhu --types evals;
 
 # Run all
 #/usr/bin/python manage.py ingest jhu

--- a/parsing/library/evals_parser.py
+++ b/parsing/library/evals_parser.py
@@ -1,0 +1,218 @@
+from selenium import webdriver
+from selenium.webdriver.support.ui import WebDriverWait
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
+import requests
+import getpass
+import os
+import json
+import time
+from tqdm import tqdm
+
+# Variable
+year = 2023
+input_file = ""  # Specify file name here, or use an empty string to download data from the Semesterly course API
+output_file = "{}/parsing/schools/jhu/data/evals.json".format(os.getcwd())
+
+# Get email and password from user input
+jhu_email = input("Enter your JHU email: ")
+jhu_password = getpass.getpass("Enter your JHU password: ")
+
+# Config
+chrome_options = webdriver.ChromeOptions()
+chrome_options.add_argument("--no-sandbox")  # Allow running chrome as root in Docker
+chrome_options.add_argument("--headless")  # Do not require a display
+chrome_options.add_argument("--disable-dev-shm-usage")  # for docker
+chrome_options.add_argument("--window-size=1920x1080")
+
+service = Service(ChromeDriverManager().install())
+driver = webdriver.Chrome(service=service, options=chrome_options)
+
+# Load courses
+if input_file:
+    with open(input_file, "r") as file:
+        courses = json.load(file)
+else:
+    response = requests.get("https://jhu.semester.ly/courses/json")
+    courses = response.json()
+
+# Open the URL
+url = "https://asen-jhu.evaluationkit.com/"
+driver.get(url)
+
+# Authentication starts here
+# Wait for the email input field and enter the email
+email_input = WebDriverWait(driver, 10).until(
+    EC.presence_of_element_located((By.ID, "i0116"))
+)
+email_input.send_keys(jhu_email)
+
+# Wait for the next button to be clickable and click it
+next_button = WebDriverWait(driver, 10).until(
+    EC.element_to_be_clickable((By.ID, "idSIButton9"))
+)
+next_button.click()
+
+# Wait for the password input field and enter the password
+password_input = WebDriverWait(driver, 10).until(
+    EC.presence_of_element_located((By.ID, "i0118"))
+)
+password_input.send_keys(jhu_password)
+
+time.sleep(1)
+
+# Wait for the sign-in button to be clickable and click it
+sign_in_button = WebDriverWait(driver, 10).until(
+    EC.element_to_be_clickable((By.ID, "idSIButton9"))
+)
+sign_in_button.click()
+
+# Start to parse evaluations on courses
+course_ratings = {}
+
+# Dictionary to convert semester codes to full names
+semester_conversion = {
+    "FA": "Fall",
+    "SP": "Spring",
+    "SU": "Summer",
+    "IN": "Intersession",
+}
+
+print(f"Total number of courses to parse: {len(courses)}")
+
+# Parse course evaluations
+with tqdm(total=len(courses), desc="Parsing Courses", unit="course") as pbar:
+    for course in courses:
+        course_name = course["name"]
+        course_code = course["code"]
+
+        # Construct the URL based on the course_name or course_code as needed
+        course_url = (
+            f"https://asen-jhu.evaluationkit.com/Report/Public/Results?"
+            f"Course={course_name}&Instructor=&TermId=&Year={year}"
+            f"&AreaId=&QuestionKey=&Search=true"
+        )
+        driver.get(course_url)
+
+        try:
+            # Continuously click on "Show more results" link while it exists
+            while True:
+                try:
+                    show_more_link = WebDriverWait(driver, 0.1).until(
+                        EC.presence_of_element_located((By.ID, "publicMore"))
+                    )
+                    show_more_link.click()
+                    time.sleep(5)
+                except:
+                    break
+
+            # After expanding all results, locate all courses
+            class_elements = driver.find_elements(
+                By.CLASS_NAME, "sr-dataitem-info-code"
+            )
+
+            if class_elements:
+                # For each located course element, parse the required information
+                for element in class_elements:
+                    class_info = element.text
+
+                    # Split and parse the course code and semester/year
+                    (
+                        course_code_with_section_parsed,
+                        semester_and_year_parsed,
+                    ) = class_info.rsplit(".", 1)
+
+                    # Check if the parsed course code matches the one we're interested in
+                    if course_code in course_code_with_section_parsed:
+                        # Find the parent element which includes both instructor name and rating
+                        parent_div = element.find_element(By.XPATH, "./..")
+
+                        try:
+                            # Attempt to extract the instructor name from the parent div
+                            professor_name_element = parent_div.find_element(
+                                By.CLASS_NAME, "sr-dataitem-info-instr"
+                            )
+                            professor_name = professor_name_element.text
+                        except Exception:
+                            # If the element is not found, set professor name as empty
+                            professor_name = ""
+
+                        rating_element = element.find_element(
+                            By.XPATH, "../following-sibling::div//strong"
+                        )
+                        rating = float(rating_element.text)
+
+                        # Organize the data in a dictionary
+                        if course_code not in course_ratings:
+                            course_ratings[course_code] = {}
+                        if semester_and_year_parsed not in course_ratings[course_code]:
+                            course_ratings[course_code][semester_and_year_parsed] = {}
+                        if (
+                            professor_name
+                            not in course_ratings[course_code][semester_and_year_parsed]
+                        ):
+                            course_ratings[course_code][semester_and_year_parsed][
+                                professor_name
+                            ] = []
+
+                        # Append the rating to the list for the specific course, semester/year, and professor
+                        course_ratings[course_code][semester_and_year_parsed][
+                            professor_name
+                        ].append(rating)
+
+                # print(f"Successfully parsed evaluations for course {course_code}")
+
+            else:
+                # print(f"No evaluations found for course {course_code}.")
+                pass
+
+        except Exception as e:
+            print(f"Exception raised with error: {e}.")
+
+        pbar.update(1)
+
+# Format the collected data and write it to a JSON file
+formatted_courses = []
+with tqdm(
+    total=len(course_ratings.items()), desc="Formatting Parsed Courses", unit="course"
+) as pbar:
+    for course_code, semesters in course_ratings.items():
+        for semester_and_year, professors in semesters.items():
+            for professor_name, ratings in professors.items():
+                average_rating = sum(ratings) / len(ratings)
+
+                # Format the semester and year
+                term, year = semester_and_year[:2], semester_and_year[2:]
+                term_full = semester_conversion.get(term, "Unknown Term")
+                year_full = f"20{year}"
+
+                # Format the professor's name
+                formatted_professor_name = " ".join(
+                    word.strip().capitalize()
+                    for word in reversed(professor_name.split(","))
+                )
+
+                formatted_course = {
+                    "course": {"code": course_code},
+                    "instructors": [{"name": formatted_professor_name}],
+                    "kind": "eval",
+                    "score": round(average_rating, 2),
+                    "summary": "",  # Empty
+                    "term": term_full,
+                    "year": term_full + ":" + year_full,
+                }
+                formatted_courses.append(formatted_course)
+        pbar.update(1)
+
+# Save the formatted data to a JSON file
+with open(output_file, "w") as outfile:
+    json.dump(
+        {"$data": formatted_courses, "$meta": {"$schools": {"jhu": {}}}},
+        outfile,
+        indent=2,
+    )
+
+print(f"Course data formatted and saved to '{output_file}'.")
+driver.quit()

--- a/parsing/schools/jhu/data/evals.json
+++ b/parsing/schools/jhu/data/evals.json
@@ -1,0 +1,22029 @@
+{
+  "$data": [
+    {
+      "course": {
+        "code": "EN.580.404"
+      },
+      "instructors": [
+        {
+          "name": "Elizabeth Logsdon"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.162"
+      },
+      "instructors": [
+        {
+          "name": "Ann Jarema"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.99,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.323"
+      },
+      "instructors": [
+        {
+          "name": "Jeffrey Bowen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.362.241"
+      },
+      "instructors": [
+        {
+          "name": "Bryan Carter"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2017"
+    },
+    {
+      "course": {
+        "code": "AS.100.252"
+      },
+      "instructors": [
+        {
+          "name": "Jules Gill peterson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.105"
+      },
+      "instructors": [
+        {
+          "name": "Joerg-uwe Szipl"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.150"
+      },
+      "instructors": [
+        {
+          "name": "Leslie Kendrick"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.377"
+      },
+      "instructors": [
+        {
+          "name": "Linda Delibero"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.51,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "AS.145.111"
+      },
+      "instructors": [
+        {
+          "name": "Dave Shade"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.104"
+      },
+      "instructors": [
+        {
+          "name": "Aniruddha Ghosh"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.233"
+      },
+      "instructors": [
+        {
+          "name": "Minal Patel"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.142"
+      },
+      "instructors": [
+        {
+          "name": "Michael Rickelton"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.114"
+      },
+      "instructors": [
+        {
+          "name": "Michael Boyle"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.410"
+      },
+      "instructors": [
+        {
+          "name": "Carl Liggio"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.410"
+      },
+      "instructors": [
+        {
+          "name": "Gabriel Thoumi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.413"
+      },
+      "instructors": [
+        {
+          "name": "Carl Liggio"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.15,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.413"
+      },
+      "instructors": [
+        {
+          "name": "Lori Simpson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.157"
+      },
+      "instructors": [
+        {
+          "name": "Andres Lares"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.225"
+      },
+      "instructors": [
+        {
+          "name": "Larissa D'souza"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.030.225"
+      },
+      "instructors": [
+        {
+          "name": "Larissa D'souza"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.225"
+      },
+      "instructors": [
+        {
+          "name": "Thomas Lectka"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.77,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.604"
+      },
+      "instructors": [
+        {
+          "name": "Lakshmi Santhanam"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.374"
+      },
+      "instructors": [
+        {
+          "name": "Anna Coppola"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.84,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.412"
+      },
+      "instructors": [
+        {
+          "name": "Loreto Sanchez"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.52,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.560.301"
+      },
+      "instructors": [
+        {
+          "name": "Cristopher Moen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.321"
+      },
+      "instructors": [
+        {
+          "name": "Rajiv Mccoy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.393"
+      },
+      "instructors": [
+        {
+          "name": "Alissa Burkholder murphy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.8,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.393"
+      },
+      "instructors": [
+        {
+          "name": "Lucas Buccafusca"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.8,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.245"
+      },
+      "instructors": [
+        {
+          "name": "Andrew Halladay"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.57,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.106"
+      },
+      "instructors": [
+        {
+          "name": "Sean Gruber"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.65,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.106"
+      },
+      "instructors": [
+        {
+          "name": "Yuchin Sun"
+        }
+      ],
+      "kind": "eval",
+      "score": 2.8,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.405"
+      },
+      "instructors": [
+        {
+          "name": "Jeffrey Marino"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.51,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.405"
+      },
+      "instructors": [
+        {
+          "name": "Chamsol Park"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.405"
+      },
+      "instructors": [
+        {
+          "name": "Jeffrey Marino"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.39,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.405"
+      },
+      "instructors": [
+        {
+          "name": "Jeffrey Marino"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.98,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.213.334"
+      },
+      "instructors": [
+        {
+          "name": "Jennifer Gosetti"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.48,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.471"
+      },
+      "instructors": [
+        {
+          "name": "Robert Kargon"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.72,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.190.471"
+      },
+      "instructors": [
+        {
+          "name": "Benjamin Ginsberg"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.75,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.520.605"
+      },
+      "instructors": [
+        {
+          "name": "Jacob Khurgin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.45,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.050.326"
+      },
+      "instructors": [
+        {
+          "name": "Paul Smolensky"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.315"
+      },
+      "instructors": [
+        {
+          "name": "John Edison"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.09,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.315"
+      },
+      "instructors": [
+        {
+          "name": "Sakul Ratanalert"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.663"
+      },
+      "instructors": [
+        {
+          "name": "Beryl Castello"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.560.255"
+      },
+      "instructors": [
+        {
+          "name": "Stavros Gaitanaros"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.304"
+      },
+      "instructors": [
+        {
+          "name": "Carsten Prasse"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.304"
+      },
+      "instructors": [
+        {
+          "name": "Peter Decarlo"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.53,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.141"
+      },
+      "instructors": [
+        {
+          "name": "Meredith Ward"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.331"
+      },
+      "instructors": [
+        {
+          "name": "Bill Smedick"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.660.331"
+      },
+      "instructors": [
+        {
+          "name": "Mia Russell"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.87,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.331"
+      },
+      "instructors": [
+        {
+          "name": "Bill Smedick"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.9,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.105"
+      },
+      "instructors": [
+        {
+          "name": "Henry Hallock"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.105"
+      },
+      "instructors": [
+        {
+          "name": "Stewart Hendry"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.46,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.407"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Zwernemann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.59,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.407"
+      },
+      "instructors": [
+        {
+          "name": "Elizabeth Logsdon"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.57,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "AS.130.352"
+      },
+      "instructors": [
+        {
+          "name": "David Katz"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.312"
+      },
+      "instructors": [
+        {
+          "name": "Collin Broholm"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.040.103"
+      },
+      "instructors": [
+        {
+          "name": "Matthew Roller"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.771"
+      },
+      "instructors": [
+        {
+          "name": "Daniel Khashabi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.520.214"
+      },
+      "instructors": [
+        {
+          "name": "Mounya Elhilali"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.371"
+      },
+      "instructors": [
+        {
+          "name": "Donniell Fishkind"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.15,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.560.192"
+      },
+      "instructors": [
+        {
+          "name": "Rachel Sangree"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.320"
+      },
+      "instructors": [
+        {
+          "name": "Stefanie Deluca"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.45,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.365"
+      },
+      "instructors": [
+        {
+          "name": "Stephen Morgan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.663"
+      },
+      "instructors": [
+        {
+          "name": "Simon Leonard"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.244"
+      },
+      "instructors": [
+        {
+          "name": "Meredith Greif"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.133.451"
+      },
+      "instructors": [
+        {
+          "name": "Marie-lys Arnette"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.111"
+      },
+      "instructors": [
+        {
+          "name": "Michael Rickelton"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.91,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.376.111"
+      },
+      "instructors": [
+        {
+          "name": "Jordan Prescott"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.111"
+      },
+      "instructors": [
+        {
+          "name": "Lisa Perry"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.370"
+      },
+      "instructors": [
+        {
+          "name": "John Yasuda"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.51,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.388"
+      },
+      "instructors": [
+        {
+          "name": "Heather Roberts fox"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.302"
+      },
+      "instructors": [
+        {
+          "name": "April Wuensch"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.302"
+      },
+      "instructors": [
+        {
+          "name": "Claire Massy-paoli"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.382"
+      },
+      "instructors": [
+        {
+          "name": "John Edison"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.15,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.738"
+      },
+      "instructors": [
+        {
+          "name": "Mauro Maggioni"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.374"
+      },
+      "instructors": [
+        {
+          "name": "Dylan Selterman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.742"
+      },
+      "instructors": [
+        {
+          "name": "Abhishek Jain"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.653"
+      },
+      "instructors": [
+        {
+          "name": "Alejandro Martin gomez"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.8,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.450"
+      },
+      "instructors": [
+        {
+          "name": "Leslie Kendrick"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.98,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.332"
+      },
+      "instructors": [
+        {
+          "name": "Mc Coghlan"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.660.332"
+      },
+      "instructors": [
+        {
+          "name": "Mc Coghlan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.363.341"
+      },
+      "instructors": [
+        {
+          "name": "Brad Harmon"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.74,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.363.341"
+      },
+      "instructors": [
+        {
+          "name": "Katrin Pahl"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.8,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.510.312"
+      },
+      "instructors": [
+        {
+          "name": "James Spicer"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.305"
+      },
+      "instructors": [
+        {
+          "name": "Chelsea Howe"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.53,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.380"
+      },
+      "instructors": [
+        {
+          "name": "Lawrence Aronhime"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.380"
+      },
+      "instructors": [
+        {
+          "name": "Alexander Cocron"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.761"
+      },
+      "instructors": [
+        {
+          "name": "Thabo Samakhoana"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.740"
+      },
+      "instructors": [
+        {
+          "name": "Yinzhi Cao"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.211"
+      },
+      "instructors": [
+        {
+          "name": "Nadejda Drenska"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.36,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.211"
+      },
+      "instructors": [
+        {
+          "name": "Mario Micheli"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.15,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.211"
+      },
+      "instructors": [
+        {
+          "name": "Zachary Pisano"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.211"
+      },
+      "instructors": [
+        {
+          "name": "Nadejda Drenska"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.51,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.211"
+      },
+      "instructors": [
+        {
+          "name": "Donniell Fishkind"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.43,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.373.415"
+      },
+      "instructors": [
+        {
+          "name": "Qian Wang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.64,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.303"
+      },
+      "instructors": [
+        {
+          "name": "Christopher Ratigan"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.303"
+      },
+      "instructors": [
+        {
+          "name": "Christopher Ratigan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.48,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.202"
+      },
+      "instructors": [
+        {
+          "name": "Noah Cowan"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.620"
+      },
+      "instructors": [
+        {
+          "name": "Soumyadipta Acharya"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.560.658"
+      },
+      "instructors": [
+        {
+          "name": "Gonzalo Pita"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.428"
+      },
+      "instructors": [
+        {
+          "name": "Jean Fan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.416"
+      },
+      "instructors": [
+        {
+          "name": "Fei Lu"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.15,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.321"
+      },
+      "instructors": [
+        {
+          "name": "Alison Papadakis"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.190.220"
+      },
+      "instructors": [
+        {
+          "name": "Daniel Deudney"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.312"
+      },
+      "instructors": [
+        {
+          "name": "Arancha Hubbard"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.312"
+      },
+      "instructors": [
+        {
+          "name": "Loreto Sanchez"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.34,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.312"
+      },
+      "instructors": [
+        {
+          "name": "Arancha Hubbard"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.202"
+      },
+      "instructors": [
+        {
+          "name": "Chamsol Park"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.65,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.202"
+      },
+      "instructors": [
+        {
+          "name": "Xiong Wang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.07,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.202"
+      },
+      "instructors": [
+        {
+          "name": "Teri Christiansen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.202"
+      },
+      "instructors": [
+        {
+          "name": "Teri Christiansen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.202"
+      },
+      "instructors": [
+        {
+          "name": "Alexander Shumakovitch"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.225.328"
+      },
+      "instructors": [
+        {
+          "name": "Joe Martin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.01,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.215.390"
+      },
+      "instructors": [
+        {
+          "name": "Eduardo Gonzalez"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.215.390"
+      },
+      "instructors": [
+        {
+          "name": "Alicia Pinar diaz"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.215.390"
+      },
+      "instructors": [
+        {
+          "name": "Rhiannon Clarke"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.378"
+      },
+      "instructors": [
+        {
+          "name": "Greg Williamson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.270.205"
+      },
+      "instructors": [
+        {
+          "name": "Xin Chen"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.307"
+      },
+      "instructors": [
+        {
+          "name": "Brandon Bangsboll"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.73,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.307"
+      },
+      "instructors": [
+        {
+          "name": "Zachery Yeager"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.73,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.211.259"
+      },
+      "instructors": [
+        {
+          "name": "Alessandro Zannirato"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.23,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.211.259"
+      },
+      "instructors": [
+        {
+          "name": "Alessandro Zannirato"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.308"
+      },
+      "instructors": [
+        {
+          "name": "Sebastian Mazzuca"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.81,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.249"
+      },
+      "instructors": [
+        {
+          "name": "Hellen Seshie-nasser"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.99,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.180.249"
+      },
+      "instructors": [
+        {
+          "name": "Hellen Seshie-nasser"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.302"
+      },
+      "instructors": [
+        {
+          "name": "Laurence Ball"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.600"
+      },
+      "instructors": [
+        {
+          "name": "Joshua Reiter"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.659"
+      },
+      "instructors": [
+        {
+          "name": "Laureano Moro velazquez"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.413"
+      },
+      "instructors": [
+        {
+          "name": "John Mann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.405"
+      },
+      "instructors": [
+        {
+          "name": "Adam Sheingate"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.440"
+      },
+      "instructors": [
+        {
+          "name": "Huei-ying Kuo"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.252"
+      },
+      "instructors": [
+        {
+          "name": "Leonardo Proietti"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.57,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.213.380"
+      },
+      "instructors": [
+        {
+          "name": "Rochelle Tobias"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.454"
+      },
+      "instructors": [
+        {
+          "name": "Sara Thoi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.140.312"
+      },
+      "instructors": [
+        {
+          "name": "Robert Kargon"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.87,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.140.312"
+      },
+      "instructors": [
+        {
+          "name": "Benjamin Ginsberg"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.88,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.101"
+      },
+      "instructors": [
+        {
+          "name": "Bob Barbera"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.88,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.180.101"
+      },
+      "instructors": [
+        {
+          "name": "Hellen Seshie-nasser"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.56,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.101"
+      },
+      "instructors": [
+        {
+          "name": "Nino Kodua"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.79,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.347"
+      },
+      "instructors": [
+        {
+          "name": "M Khan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.401"
+      },
+      "instructors": [
+        {
+          "name": "Richard Bett"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.301"
+      },
+      "instructors": [
+        {
+          "name": "Chia ling Chien"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.520.650"
+      },
+      "instructors": [
+        {
+          "name": "Rama Chellappa"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.785"
+      },
+      "instructors": [
+        {
+          "name": "David Kaplan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.721"
+      },
+      "instructors": [
+        {
+          "name": "Holden Lee"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.52,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.317"
+      },
+      "instructors": [
+        {
+          "name": "Jenny Bernstein"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.225.201"
+      },
+      "instructors": [
+        {
+          "name": "Gerrad Taylor"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.639"
+      },
+      "instructors": [
+        {
+          "name": "Sergey Kushnarev"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.99,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.471"
+      },
+      "instructors": [
+        {
+          "name": "Elizabeth Linton"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.449"
+      },
+      "instructors": [
+        {
+          "name": "Colin Norman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.345"
+      },
+      "instructors": [
+        {
+          "name": "Jay Baraban"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.623"
+      },
+      "instructors": [
+        {
+          "name": "Jim Bellingham"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.59,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.762"
+      },
+      "instructors": [
+        {
+          "name": "Ben Grimmer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.560.112"
+      },
+      "instructors": [
+        {
+          "name": "Ben Schafer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.670"
+      },
+      "instructors": [
+        {
+          "name": "Herman Goodyear"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.54,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.381"
+      },
+      "instructors": [
+        {
+          "name": "Juliette Lecomte"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.619"
+      },
+      "instructors": [
+        {
+          "name": "Soumya Acharya"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.55,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.171.108"
+      },
+      "instructors": [
+        {
+          "name": "Petar Maksimovic"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.108"
+      },
+      "instructors": [
+        {
+          "name": "David Sing"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.01,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.108"
+      },
+      "instructors": [
+        {
+          "name": "David Nataf"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.192.410"
+      },
+      "instructors": [
+        {
+          "name": "Francis Gavin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.72,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.192.410"
+      },
+      "instructors": [
+        {
+          "name": "Hal Brands"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.72,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.145.205"
+      },
+      "instructors": [
+        {
+          "name": "Alicia Puglionesi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.373.216"
+      },
+      "instructors": [
+        {
+          "name": "Shuyi Yang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.45,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.373.216"
+      },
+      "instructors": [
+        {
+          "name": "Aiguo Chen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.417"
+      },
+      "instructors": [
+        {
+          "name": "Kristin Cook-gailloud"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.270"
+      },
+      "instructors": [
+        {
+          "name": "Victoria Harms"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.26,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.628"
+      },
+      "instructors": [
+        {
+          "name": "Roza Galeeva"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.428"
+      },
+      "instructors": [
+        {
+          "name": "Steve Hanke"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.56,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.679"
+      },
+      "instructors": [
+        {
+          "name": "Wojciech Zbijewski"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.215.406"
+      },
+      "instructors": [
+        {
+          "name": "Becquer Seguin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.520.607"
+      },
+      "instructors": [
+        {
+          "name": "Jacob Khurgin"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.050.337"
+      },
+      "instructors": [
+        {
+          "name": "Donald Li"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.277"
+      },
+      "instructors": [
+        {
+          "name": "Flavia De azeredo cerqueira"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.79,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.277"
+      },
+      "instructors": [
+        {
+          "name": "Benjamin Chaffin"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.289"
+      },
+      "instructors": [
+        {
+          "name": "Gatien De broucker"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.79,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.171.324"
+      },
+      "instructors": [
+        {
+          "name": "Brice Menard"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.319"
+      },
+      "instructors": [
+        {
+          "name": "Kyle Cunningham"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.319"
+      },
+      "instructors": [
+        {
+          "name": "Rajiv Mccoy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.606"
+      },
+      "instructors": [
+        {
+          "name": "Yahui Zhang"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.310.340"
+      },
+      "instructors": [
+        {
+          "name": "Gaochao He"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.07,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.675"
+      },
+      "instructors": [
+        {
+          "name": "Len Foxwell"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.665"
+      },
+      "instructors": [
+        {
+          "name": "Rama Chellappa"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.85,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.429"
+      },
+      "instructors": [
+        {
+          "name": "Scott Smith"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.070.317"
+      },
+      "instructors": [
+        {
+          "name": "Niloofar Haeri"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.646"
+      },
+      "instructors": [
+        {
+          "name": "Trac duy Tran"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.319"
+      },
+      "instructors": [
+        {
+          "name": "Naiara Martinez-velez"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.319"
+      },
+      "instructors": [
+        {
+          "name": "Carmen Torres burgos"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.510.425"
+      },
+      "instructors": [
+        {
+          "name": "Mingwei Chen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.315"
+      },
+      "instructors": [
+        {
+          "name": "Lucy Bucknell"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.49,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.060.219"
+      },
+      "instructors": [
+        {
+          "name": "Jared Hickman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.58,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.220"
+      },
+      "instructors": [
+        {
+          "name": "Brandon Bangsboll"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.92,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.220"
+      },
+      "instructors": [
+        {
+          "name": "Zachery Yeager"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.92,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.220"
+      },
+      "instructors": [
+        {
+          "name": "Michael Lieske"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.92,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.220"
+      },
+      "instructors": [
+        {
+          "name": "Tim Leung"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.92,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.688"
+      },
+      "instructors": [
+        {
+          "name": "Dan Naiman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.688"
+      },
+      "instructors": [
+        {
+          "name": "Dan Naiman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.85,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.330"
+      },
+      "instructors": [
+        {
+          "name": "Daeyeol Lee"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.01,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.335"
+      },
+      "instructors": [
+        {
+          "name": "Steven Marra"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.646"
+      },
+      "instructors": [
+        {
+          "name": "Jamie Spangler"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.560.731"
+      },
+      "instructors": [
+        {
+          "name": "Sandor Adany"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.647"
+      },
+      "instructors": [
+        {
+          "name": "Patrick Cahan"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.78,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.456"
+      },
+      "instructors": [
+        {
+          "name": "Katharine Noel"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.69,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.389.315"
+      },
+      "instructors": [
+        {
+          "name": "Sanchita Balachandran"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.313"
+      },
+      "instructors": [
+        {
+          "name": "Carmen Torres burgos"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.68,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.313"
+      },
+      "instructors": [
+        {
+          "name": "Rosario Ramos"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.46,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.313"
+      },
+      "instructors": [
+        {
+          "name": "Carmen Torres burgos"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.39,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.373.314"
+      },
+      "instructors": [
+        {
+          "name": "Aiguo Chen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.641"
+      },
+      "instructors": [
+        {
+          "name": "Abhishek Jain"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.641"
+      },
+      "instructors": [
+        {
+          "name": "Matthew Green"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.211.315"
+      },
+      "instructors": [
+        {
+          "name": "Samuel Spinner"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.78,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.211.315"
+      },
+      "instructors": [
+        {
+          "name": "Alice Mandell"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.212.340"
+      },
+      "instructors": [
+        {
+          "name": "Suzanne Roos"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.262"
+      },
+      "instructors": [
+        {
+          "name": "Tamer El-leithy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.320"
+      },
+      "instructors": [
+        {
+          "name": "Scot Miller"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.626"
+      },
+      "instructors": [
+        {
+          "name": "Scott Smith"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.54,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.201"
+      },
+      "instructors": [
+        {
+          "name": "Jeffrey Bowen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.401"
+      },
+      "instructors": [
+        {
+          "name": "Jason Trageser"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.303"
+      },
+      "instructors": [
+        {
+          "name": "Emily Fisher"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.76,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.303"
+      },
+      "instructors": [
+        {
+          "name": "Andrew Gordus"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.61,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.303"
+      },
+      "instructors": [
+        {
+          "name": "Emily Fisher"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.55,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.560.619"
+      },
+      "instructors": [
+        {
+          "name": "Jamie Guest"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.54,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.150.424"
+      },
+      "instructors": [
+        {
+          "name": "Lucy Allais"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.56,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.104"
+      },
+      "instructors": [
+        {
+          "name": "Daniel Reich"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.98,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.647"
+      },
+      "instructors": [
+        {
+          "name": "David Audley"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.452"
+      },
+      "instructors": [
+        {
+          "name": "Jess Dunleavey"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.452"
+      },
+      "instructors": [
+        {
+          "name": "Jess Dunleavey"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.43,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.452"
+      },
+      "instructors": [
+        {
+          "name": "Jessica Dunleavey"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.010.102"
+      },
+      "instructors": [
+        {
+          "name": "Rebecca Brown"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.373.316"
+      },
+      "instructors": [
+        {
+          "name": "Aiguo Chen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.212"
+      },
+      "instructors": [
+        {
+          "name": "Noah Cowan"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.271.360"
+      },
+      "instructors": [
+        {
+          "name": "Benjamin Zaitchik"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.271.360"
+      },
+      "instructors": [
+        {
+          "name": "Darryn Waugh"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.112"
+      },
+      "instructors": [
+        {
+          "name": "Fred Torcaso"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.170"
+      },
+      "instructors": [
+        {
+          "name": "Tobie Meyer-fong"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.241"
+      },
+      "instructors": [
+        {
+          "name": "David Kraemer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.01,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.353"
+      },
+      "instructors": [
+        {
+          "name": "Mahyar Fazlyab"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.65,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.344"
+      },
+      "instructors": [
+        {
+          "name": "Kirsten Bohn"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.344"
+      },
+      "instructors": [
+        {
+          "name": "Kirsten Bohn"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.56,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.172.633"
+      },
+      "instructors": [
+        {
+          "name": "Ethan Vishniac"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.52,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.130.119"
+      },
+      "instructors": [
+        {
+          "name": "Richard Jasnow"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.56,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.407"
+      },
+      "instructors": [
+        {
+          "name": "Adam Rodgers"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.43,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.422"
+      },
+      "instructors": [
+        {
+          "name": "William Rowe"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.635"
+      },
+      "instructors": [
+        {
+          "name": "Anil Maybhate"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.85,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.355"
+      },
+      "instructors": [
+        {
+          "name": "Erin Chung"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.54,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.315"
+      },
+      "instructors": [
+        {
+          "name": "Eric Johnson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.315"
+      },
+      "instructors": [
+        {
+          "name": "Eric Johnson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.213.374"
+      },
+      "instructors": [
+        {
+          "name": "Jennifer Gosetti"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.43,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.363.335"
+      },
+      "instructors": [
+        {
+          "name": "Cj Higgins"
+        }
+      ],
+      "kind": "eval",
+      "score": 2.98,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.242"
+      },
+      "instructors": [
+        {
+          "name": "Aleksander Popel"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.52,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.760"
+      },
+      "instructors": [
+        {
+          "name": "Misha Kazhdan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.360.105"
+      },
+      "instructors": [
+        {
+          "name": "Sloane Hanley"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.360.105"
+      },
+      "instructors": [
+        {
+          "name": "Ruth Sherman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.360.105"
+      },
+      "instructors": [
+        {
+          "name": "Steve Malvaso"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.360.105"
+      },
+      "instructors": [
+        {
+          "name": "Sloane Hanley"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.9,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.360.105"
+      },
+      "instructors": [
+        {
+          "name": "Ruth Sherman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.360.105"
+      },
+      "instructors": [
+        {
+          "name": "Paul Davidson"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.360.105"
+      },
+      "instructors": [
+        {
+          "name": "Kaitlin Quigley"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.74,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.360.105"
+      },
+      "instructors": [
+        {
+          "name": "Jenna Hoffman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.73,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.360.105"
+      },
+      "instructors": [
+        {
+          "name": "Michael Gonzales"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.9,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.530.679"
+      },
+      "instructors": [
+        {
+          "name": "Ryan Hurley"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.510.604"
+      },
+      "instructors": [
+        {
+          "name": "Todd Hufnagel"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.91,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.752"
+      },
+      "instructors": [
+        {
+          "name": "Kevin Yarema"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.201"
+      },
+      "instructors": [
+        {
+          "name": "Suzanne Roos"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.87,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.201"
+      },
+      "instructors": [
+        {
+          "name": "Jean-ederson Jean-pierre"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.89,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.201"
+      },
+      "instructors": [
+        {
+          "name": "Suzanne Roos"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.418"
+      },
+      "instructors": [
+        {
+          "name": "Dave Shade"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.98,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.373.116"
+      },
+      "instructors": [
+        {
+          "name": "Shuyi Yang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.62,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.373.116"
+      },
+      "instructors": [
+        {
+          "name": "Nan Zhao"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.62,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.380"
+      },
+      "instructors": [
+        {
+          "name": "Suzanne Roos"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.540.671"
+      },
+      "instructors": [
+        {
+          "name": "Paulette Clancy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.295"
+      },
+      "instructors": [
+        {
+          "name": "Angus Burgin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.65,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.627"
+      },
+      "instructors": [
+        {
+          "name": "Alejandro Sisniega crespo"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.627"
+      },
+      "instructors": [
+        {
+          "name": "Ali Uneri"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.363.360"
+      },
+      "instructors": [
+        {
+          "name": "Jo Giardini"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.626"
+      },
+      "instructors": [
+        {
+          "name": "Konstantinos Konstantopoulos"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.625"
+      },
+      "instructors": [
+        {
+          "name": "Charles Meneveau"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.56,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.605"
+      },
+      "instructors": [
+        {
+          "name": "Vicky Nguyen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.68,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.200.401"
+      },
+      "instructors": [
+        {
+          "name": "Heather Roberts fox"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.58,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.482"
+      },
+      "instructors": [
+        {
+          "name": "Anne Barnhill"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.180.102"
+      },
+      "instructors": [
+        {
+          "name": "Muhammad Husain"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.72,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.102"
+      },
+      "instructors": [
+        {
+          "name": "Xudong Zheng"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.49,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.501"
+      },
+      "instructors": [
+        {
+          "name": ""
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.001.146"
+      },
+      "instructors": [
+        {
+          "name": "Barbara Landau"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.07,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.682"
+      },
+      "instructors": [
+        {
+          "name": "Mathias Unberath"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.001.169"
+      },
+      "instructors": [
+        {
+          "name": "Lena Denis"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.85,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.001.169"
+      },
+      "instructors": [
+        {
+          "name": "Lori Finkelstein"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.76,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.220"
+      },
+      "instructors": [
+        {
+          "name": "Kyeong-soo Kim"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.68,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.010.322"
+      },
+      "instructors": [
+        {
+          "name": "Nino Zchomelidse"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.061.159"
+      },
+      "instructors": [
+        {
+          "name": "Suzanne Roos"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.91,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.061.159"
+      },
+      "instructors": [
+        {
+          "name": "John Mann"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.89,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.061.159"
+      },
+      "instructors": [
+        {
+          "name": "Lucy Bucknell"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.061.159"
+      },
+      "instructors": [
+        {
+          "name": "Linda Delibero"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.171.204"
+      },
+      "instructors": [
+        {
+          "name": "Ibou Bah"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.242"
+      },
+      "instructors": [
+        {
+          "name": "Ludmila Poliakova"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.99,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.313"
+      },
+      "instructors": [
+        {
+          "name": "Lucy Bucknell"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.100.190"
+      },
+      "instructors": [
+        {
+          "name": "Leah Wright rigueur"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.100.251"
+      },
+      "instructors": [
+        {
+          "name": "Thomas Keegan"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.69,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.304"
+      },
+      "instructors": [
+        {
+          "name": "Emily Fisher"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.304"
+      },
+      "instructors": [
+        {
+          "name": "Robert Johnston"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.180.239"
+      },
+      "instructors": [
+        {
+          "name": "Sohani Fatehin"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.77,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.406"
+      },
+      "instructors": [
+        {
+          "name": "Christopher Lebron"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.66,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.180.223"
+      },
+      "instructors": [
+        {
+          "name": "Hellen Seshie-nasser"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.7,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.190.423"
+      },
+      "instructors": [
+        {
+          "name": "Daniel Deudney"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.560.772"
+      },
+      "instructors": [
+        {
+          "name": "Somnath Ghosh"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.668"
+      },
+      "instructors": [
+        {
+          "name": "Eric Rice"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.96,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.778"
+      },
+      "instructors": [
+        {
+          "name": "Ilya Shpitser"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.473"
+      },
+      "instructors": [
+        {
+          "name": "Steven Teles"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.67,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.200.202"
+      },
+      "instructors": [
+        {
+          "name": "Chelsea Howe"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.15,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.510.603"
+      },
+      "instructors": [
+        {
+          "name": "Tine Curk"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.050.349"
+      },
+      "instructors": [
+        {
+          "name": "Julia Yarmolinskaya"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.731"
+      },
+      "instructors": [
+        {
+          "name": "Avanti Athreya"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.270.202"
+      },
+      "instructors": [
+        {
+          "name": "Meghan Avolio"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.01,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.510.615"
+      },
+      "instructors": [
+        {
+          "name": "Patty Mcguiggan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.26,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.225.305"
+      },
+      "instructors": [
+        {
+          "name": "Gerrad Taylor"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.520.363"
+      },
+      "instructors": [
+        {
+          "name": "Andreas Andreou"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.52,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.171"
+      },
+      "instructors": [
+        {
+          "name": "Sammy Khalife"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.171"
+      },
+      "instructors": [
+        {
+          "name": "Beryl Castello"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.171"
+      },
+      "instructors": [
+        {
+          "name": "Donniell Fishkind"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.51,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.236"
+      },
+      "instructors": [
+        {
+          "name": "Rhiannon Miller"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.49,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.060.385"
+      },
+      "instructors": [
+        {
+          "name": "Mitchell Cram"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.09,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.270.220"
+      },
+      "instructors": [
+        {
+          "name": "Daniel Viete"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.270.220"
+      },
+      "instructors": [
+        {
+          "name": "Emmy Smith"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.469"
+      },
+      "instructors": [
+        {
+          "name": "Emily Scott"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.540.699"
+      },
+      "instructors": [
+        {
+          "name": "Stavroula Sofou"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.26,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.500.112"
+      },
+      "instructors": [
+        {
+          "name": "Patricio Simari"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.500.112"
+      },
+      "instructors": [
+        {
+          "name": "Joanne Selinski"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.500.112"
+      },
+      "instructors": [
+        {
+          "name": "Sara More"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.112"
+      },
+      "instructors": [
+        {
+          "name": "Greg Anderson"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.8,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.112"
+      },
+      "instructors": [
+        {
+          "name": "Patricio Simari"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.07,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.112"
+      },
+      "instructors": [
+        {
+          "name": "Ivan Sekyonda"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.371.226"
+      },
+      "instructors": [
+        {
+          "name": "Sasha Baskin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.206"
+      },
+      "instructors": [
+        {
+          "name": "Christopher Falzone"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.72,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.206"
+      },
+      "instructors": [
+        {
+          "name": "Rebekka Klausen"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.96,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.206"
+      },
+      "instructors": [
+        {
+          "name": "Eric Hill"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.09,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.510.622"
+      },
+      "instructors": [
+        {
+          "name": "Anthony shoji Hall"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.39,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.112"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Tracy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.112"
+      },
+      "instructors": [
+        {
+          "name": "Grecia Chirinos delgado"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.112"
+      },
+      "instructors": [
+        {
+          "name": "Alexis Hernando cubas"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.648"
+      },
+      "instructors": [
+        {
+          "name": "Xiongyi Huang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.271.107"
+      },
+      "instructors": [
+        {
+          "name": "Jana Kopelent-rehak"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.65,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.409"
+      },
+      "instructors": [
+        {
+          "name": "Brandon Bukowski"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.362.315"
+      },
+      "instructors": [
+        {
+          "name": "Stuart Schrader"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.63,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.624"
+      },
+      "instructors": [
+        {
+          "name": "Danielle Evans"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.7,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.244"
+      },
+      "instructors": [
+        {
+          "name": "Wendel Patrick"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.376.244"
+      },
+      "instructors": [
+        {
+          "name": "Wendel Patrick"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.662.692"
+      },
+      "instructors": [
+        {
+          "name": "Pam Sheff"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.58,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.780"
+      },
+      "instructors": [
+        {
+          "name": "Laurent Younes"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.500.551"
+      },
+      "instructors": [
+        {
+          "name": ""
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.050.212"
+      },
+      "instructors": [
+        {
+          "name": "Kyle Rawlins"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.9,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.641"
+      },
+      "instructors": [
+        {
+          "name": "Kevin Yarema"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.15,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.710"
+      },
+      "instructors": [
+        {
+          "name": "Rachel Karchin"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.4,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.152"
+      },
+      "instructors": [
+        {
+          "name": "Alessandro Zannirato"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.9,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.152"
+      },
+      "instructors": [
+        {
+          "name": "Leonardo Proietti"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.442"
+      },
+      "instructors": [
+        {
+          "name": "Abhishek Jain"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.633"
+      },
+      "instructors": [
+        {
+          "name": "Gagan Garg"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.23,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.510.434"
+      },
+      "instructors": [
+        {
+          "name": "Orla Wilson"
+        }
+      ],
+      "kind": "eval",
+      "score": 5.0,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.661"
+      },
+      "instructors": [
+        {
+          "name": "Jj Rorie"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.150"
+      },
+      "instructors": [
+        {
+          "name": "Jin Kang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.01,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.620"
+      },
+      "instructors": [
+        {
+          "name": "Pedro Irazoqui"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.270.349"
+      },
+      "instructors": [
+        {
+          "name": "Eric Yee"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.638"
+      },
+      "instructors": [
+        {
+          "name": "Vishal Patel"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.09,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.764"
+      },
+      "instructors": [
+        {
+          "name": "James Spall"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.424"
+      },
+      "instructors": [
+        {
+          "name": "Richard Panek"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.26,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.611"
+      },
+      "instructors": [
+        {
+          "name": "Kevin Schlaufman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.105"
+      },
+      "instructors": [
+        {
+          "name": "Jamie Young"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.030.623"
+      },
+      "instructors": [
+        {
+          "name": "Stephen Fried"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.39,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.510.636"
+      },
+      "instructors": [
+        {
+          "name": "Luo Gu"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.404"
+      },
+      "instructors": [
+        {
+          "name": "Gretar Tryggvason"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.53,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.404"
+      },
+      "instructors": [
+        {
+          "name": "Stephen Belkoff"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Hye ji Choi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.34,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Ralph Hubbell"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Dylan Carpenter"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Samantha Neugebauer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Josiah Cox"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Samantha Neugebauer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Dagan Brown"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Brett Kessler"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Landen Raszick"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.06,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Megan Robinson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Dom Guida"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.91,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Carlee Jensen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Nicole Tsuno"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Olakunle Ologunro"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Sam Niven"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.71,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Jameson Owens"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Gabriel Schicchi"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.84,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Cora Clark"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.46,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Gabriella Fee"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.105"
+      },
+      "instructors": [
+        {
+          "name": "Samantha Neugebauer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.302"
+      },
+      "instructors": [
+        {
+          "name": "Yifu Zhou"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.68,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.302"
+      },
+      "instructors": [
+        {
+          "name": "Nicholas Marshburn"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.302"
+      },
+      "instructors": [
+        {
+          "name": "Benjamin Dodson"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.04,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.302"
+      },
+      "instructors": [
+        {
+          "name": "Nicholas Marshburn"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.662.611"
+      },
+      "instructors": [
+        {
+          "name": "Annette Leps"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.494"
+      },
+      "instructors": [
+        {
+          "name": "Alejandro Sisniega crespo"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.618"
+      },
+      "instructors": [
+        {
+          "name": "Julie Reiser"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.65,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.270.325"
+      },
+      "instructors": [
+        {
+          "name": "Anand Gnanadesikan"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.99,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.288"
+      },
+      "instructors": [
+        {
+          "name": "Flavia De azeredo cerqueira"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.23,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.111"
+      },
+      "instructors": [
+        {
+          "name": "Robbie Shilliam"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.140.329"
+      },
+      "instructors": [
+        {
+          "name": "Emily Clark"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.145.106"
+      },
+      "instructors": [
+        {
+          "name": "Marina Bedran"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.145.106"
+      },
+      "instructors": [
+        {
+          "name": "Nicole Labruto"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.145.106"
+      },
+      "instructors": [
+        {
+          "name": "Lijing Jiang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.530.646"
+      },
+      "instructors": [
+        {
+          "name": "Jin Kim"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.616"
+      },
+      "instructors": [
+        {
+          "name": "David Goldberg"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.010.407"
+      },
+      "instructors": [
+        {
+          "name": "Lisa Deleonardis"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.212"
+      },
+      "instructors": [
+        {
+          "name": "Maru Sarazola duarte"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.191.358"
+      },
+      "instructors": [
+        {
+          "name": "Juliana Butron"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.540.605"
+      },
+      "instructors": [
+        {
+          "name": "Rebecca Schulman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.485"
+      },
+      "instructors": [
+        {
+          "name": "Natalia Trayanova"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.8,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.200.333"
+      },
+      "instructors": [
+        {
+          "name": "Steve Drigotas"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.797"
+      },
+      "instructors": [
+        {
+          "name": "Nicolas Charon"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.43,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.560.657"
+      },
+      "instructors": [
+        {
+          "name": "Gonzalo Pita"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.367"
+      },
+      "instructors": [
+        {
+          "name": "Shere Abbott"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.92,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.375.116"
+      },
+      "instructors": [
+        {
+          "name": "Sana Jafire"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.130.420"
+      },
+      "instructors": [
+        {
+          "name": "Marian Feldman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.201"
+      },
+      "instructors": [
+        {
+          "name": "Sarah Preheim"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.01,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.402"
+      },
+      "instructors": [
+        {
+          "name": "Heather Roberts fox"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.72,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.133"
+      },
+      "instructors": [
+        {
+          "name": "Soumyajit Ray"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.8,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.500.133"
+      },
+      "instructors": [
+        {
+          "name": "Soumyajit Ray"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.72,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.133"
+      },
+      "instructors": [
+        {
+          "name": "Soumyajit Ray"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.69,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.133"
+      },
+      "instructors": [
+        {
+          "name": "Soumyajit Ray"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.75,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.225.318"
+      },
+      "instructors": [
+        {
+          "name": "Margaret Denithorne"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.614"
+      },
+      "instructors": [
+        {
+          "name": "Youseph Yazdi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.614"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Zwernemann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.614"
+      },
+      "instructors": [
+        {
+          "name": "Soumyadipta Acharya"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.614"
+      },
+      "instructors": [
+        {
+          "name": "April Zambelli-weiner"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.51,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.720"
+      },
+      "instructors": [
+        {
+          "name": "Scott Wilson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.350"
+      },
+      "instructors": [
+        {
+          "name": "Steven Salzberg"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.433"
+      },
+      "instructors": [
+        {
+          "name": "Gagan Garg"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.96,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.320"
+      },
+      "instructors": [
+        {
+          "name": "Andrew Hoyt"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.97,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.305"
+      },
+      "instructors": [
+        {
+          "name": "D Fairbrother"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.99,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.060.374"
+      },
+      "instructors": [
+        {
+          "name": "Daniel Mcclurkin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.43,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.150.422"
+      },
+      "instructors": [
+        {
+          "name": "Robert Rynasiewicz"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.145.222"
+      },
+      "instructors": [
+        {
+          "name": "Soha Bayoumi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.34,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.140.387"
+      },
+      "instructors": [
+        {
+          "name": "Ahmed Ragab"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.299"
+      },
+      "instructors": [
+        {
+          "name": "Shirley Yoo"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.070.273"
+      },
+      "instructors": [
+        {
+          "name": "Scott Maclochlainn"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.49,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.171.708"
+      },
+      "instructors": [
+        {
+          "name": "Emanuele Berti"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.329"
+      },
+      "instructors": [
+        {
+          "name": "Bill Smedick"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.26,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.660.329"
+      },
+      "instructors": [
+        {
+          "name": "Bill Smedick"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.217.425"
+      },
+      "instructors": [
+        {
+          "name": "Marina Bedran"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.128"
+      },
+      "instructors": [
+        {
+          "name": "Mc Coghlan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.660"
+      },
+      "instructors": [
+        {
+          "name": "Eric Rice"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.06,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.376"
+      },
+      "instructors": [
+        {
+          "name": "Susanne Sterbing-d'angelo"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.280"
+      },
+      "instructors": [
+        {
+          "name": "Ali Madooei"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.150.245"
+      },
+      "instructors": [
+        {
+          "name": "Ian Phillips"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.352"
+      },
+      "instructors": [
+        {
+          "name": "Giulia m. Cipriani"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.251"
+      },
+      "instructors": [
+        {
+          "name": "Alessandro Zannirato"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.39,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.251"
+      },
+      "instructors": [
+        {
+          "name": "Leonardo Proietti"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.39,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.061.404"
+      },
+      "instructors": [
+        {
+          "name": "Adam Rodgers"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.49,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.061.270"
+      },
+      "instructors": [
+        {
+          "name": "Kyle Stine"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.83,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.375.115"
+      },
+      "instructors": [
+        {
+          "name": "Sana Jafire"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.060.384"
+      },
+      "instructors": [
+        {
+          "name": "Chris Nealon"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.54,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.171.749"
+      },
+      "instructors": [
+        {
+          "name": "Brice Menard"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.040.204"
+      },
+      "instructors": [
+        {
+          "name": "Juan Dopico"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.07,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.130.247"
+      },
+      "instructors": [
+        {
+          "name": "Karlene Shippelhoute"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.660.300"
+      },
+      "instructors": [
+        {
+          "name": "Marco Priolo"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.660.300"
+      },
+      "instructors": [
+        {
+          "name": "Michael Kitt"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.45,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.202"
+      },
+      "instructors": [
+        {
+          "name": "Brandon Bangsboll"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.202"
+      },
+      "instructors": [
+        {
+          "name": "Zachery Yeager"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.202"
+      },
+      "instructors": [
+        {
+          "name": "Michael Lieske"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.202"
+      },
+      "instructors": [
+        {
+          "name": "Tim Leung"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.771"
+      },
+      "instructors": [
+        {
+          "name": "Nitish Thakor"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.560.661"
+      },
+      "instructors": [
+        {
+          "name": "Jochen Mueller"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.001.190"
+      },
+      "instructors": [
+        {
+          "name": "Lan Li"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.374.320"
+      },
+      "instructors": [
+        {
+          "name": "Brandon Bangsboll"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.320"
+      },
+      "instructors": [
+        {
+          "name": "Shaun Stoner"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.320"
+      },
+      "instructors": [
+        {
+          "name": "Zachery Yeager"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.34,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.248"
+      },
+      "instructors": [
+        {
+          "name": "Floyd Norris"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.62,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.180.248"
+      },
+      "instructors": [
+        {
+          "name": "Floyd Norris"
+        }
+      ],
+      "kind": "eval",
+      "score": 2.92,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.378.216"
+      },
+      "instructors": [
+        {
+          "name": "Makiko Nakao"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.396"
+      },
+      "instructors": [
+        {
+          "name": "Laura Mason"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.303"
+      },
+      "instructors": [
+        {
+          "name": "Stavroula Sofou"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.792"
+      },
+      "instructors": [
+        {
+          "name": "Donniell Fishkind"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.52,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.200.403"
+      },
+      "instructors": [
+        {
+          "name": "Heather Roberts fox"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.140.149"
+      },
+      "instructors": [
+        {
+          "name": "Lan Li"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.140.340"
+      },
+      "instructors": [
+        {
+          "name": "Ryan Hearty"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.26,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.161"
+      },
+      "instructors": [
+        {
+          "name": "Deborah Mifflin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.56,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.161"
+      },
+      "instructors": [
+        {
+          "name": "Lisa Schmitz"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.161"
+      },
+      "instructors": [
+        {
+          "name": "K\u00e4the Erichsen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.69,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.417"
+      },
+      "instructors": [
+        {
+          "name": "Yannick Sire"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.69,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.365"
+      },
+      "instructors": [
+        {
+          "name": "Deborah Mifflin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.365"
+      },
+      "instructors": [
+        {
+          "name": "Lisa Schmitz"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.43,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.172"
+      },
+      "instructors": [
+        {
+          "name": "Drg Gnang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.41,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.660.203"
+      },
+      "instructors": [
+        {
+          "name": "Sean Furlong"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.203"
+      },
+      "instructors": [
+        {
+          "name": "Annette Leps"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.203"
+      },
+      "instructors": [
+        {
+          "name": "Jane Schlegel"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.203"
+      },
+      "instructors": [
+        {
+          "name": "Lawrence Aronhime"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.92,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.741"
+      },
+      "instructors": [
+        {
+          "name": "James Schmidt"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.670"
+      },
+      "instructors": [
+        {
+          "name": "Benjamin Van durme"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.030.245"
+      },
+      "instructors": [
+        {
+          "name": "Sunita Thyagarajan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.362.216"
+      },
+      "instructors": [
+        {
+          "name": "Lester Spence"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.343"
+      },
+      "instructors": [
+        {
+          "name": "Louis Whitcomb"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.470"
+      },
+      "instructors": [
+        {
+          "name": "Brett Shapiro"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.470"
+      },
+      "instructors": [
+        {
+          "name": "Pradipto Ghosh"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.437"
+      },
+      "instructors": [
+        {
+          "name": "Bruce Snider"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.72,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.238"
+      },
+      "instructors": [
+        {
+          "name": "Lucy Bucknell"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.377"
+      },
+      "instructors": [
+        {
+          "name": "Susanne Sterbing-d'angelo"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.668"
+      },
+      "instructors": [
+        {
+          "name": "Chen Li"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.75,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.070.334"
+      },
+      "instructors": [
+        {
+          "name": "Anand Pandian"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.88,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.240"
+      },
+      "instructors": [
+        {
+          "name": "Heather Roberts fox"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.89,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.275"
+      },
+      "instructors": [
+        {
+          "name": "Nicholas Marshburn"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.130.216"
+      },
+      "instructors": [
+        {
+          "name": "David Katz"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.605"
+      },
+      "instructors": [
+        {
+          "name": "Oleg Tchernyshyov"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.190.101"
+      },
+      "instructors": [
+        {
+          "name": "Robert Lieberman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.78,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.656"
+      },
+      "instructors": [
+        {
+          "name": "Nitish Thakor"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.77,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.560.633"
+      },
+      "instructors": [
+        {
+          "name": "Anthoy Dondrea"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.560.633"
+      },
+      "instructors": [
+        {
+          "name": "Joe Rogers"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.108"
+      },
+      "instructors": [
+        {
+          "name": "Amanda Clayton"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.45,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.228"
+      },
+      "instructors": [
+        {
+          "name": "Benjamin Ginsberg"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.53,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.520.621"
+      },
+      "instructors": [
+        {
+          "name": "Pablo Iglesias"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.510.106"
+      },
+      "instructors": [
+        {
+          "name": "Jonah Erlebacher"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.742"
+      },
+      "instructors": [
+        {
+          "name": "Gene Fridman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.99,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.347"
+      },
+      "instructors": [
+        {
+          "name": "Linda Delibero"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.010.413"
+      },
+      "instructors": [
+        {
+          "name": "Jennifer Stager"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.137"
+      },
+      "instructors": [
+        {
+          "name": "Trac duy Tran"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.246"
+      },
+      "instructors": [
+        {
+          "name": "Sri Sarma"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.743"
+      },
+      "instructors": [
+        {
+          "name": "Avi Rubin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.54,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.271.499"
+      },
+      "instructors": [
+        {
+          "name": "Ashley Schantz"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.82,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.271.499"
+      },
+      "instructors": [
+        {
+          "name": "Jerry Burgess"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.84,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.230.370"
+      },
+      "instructors": [
+        {
+          "name": "Meredith Greif"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.230.395"
+      },
+      "instructors": [
+        {
+          "name": "Michael Levien"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.61,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.410"
+      },
+      "instructors": [
+        {
+          "name": "Emily Fisher"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.410"
+      },
+      "instructors": [
+        {
+          "name": "Katie Tifft oshinnaiye"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.410"
+      },
+      "instructors": [
+        {
+          "name": "Christov Roberson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.105"
+      },
+      "instructors": [
+        {
+          "name": "Alexa Gaines"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.105"
+      },
+      "instructors": [
+        {
+          "name": "Alexa Gaines"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.402"
+      },
+      "instructors": [
+        {
+          "name": "Michael Betenbaugh"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.520.637"
+      },
+      "instructors": [
+        {
+          "name": "Enrique Mallada garcia"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.500.132"
+      },
+      "instructors": [
+        {
+          "name": "Milad Alemohammad"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.500.132"
+      },
+      "instructors": [
+        {
+          "name": "Ivan Sekyonda"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.78,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.132"
+      },
+      "instructors": [
+        {
+          "name": "Ali Madooei"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.132"
+      },
+      "instructors": [
+        {
+          "name": "Joanne Selinski"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.153"
+      },
+      "instructors": [
+        {
+          "name": "Kathy Wilson"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.66,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.380"
+      },
+      "instructors": [
+        {
+          "name": "Marina Bedny"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.662"
+      },
+      "instructors": [
+        {
+          "name": "Andrew Motion"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.230.242"
+      },
+      "instructors": [
+        {
+          "name": "Zophia Edwards"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.030.306"
+      },
+      "instructors": [
+        {
+          "name": "Thomas Kempa"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.82,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.413"
+      },
+      "instructors": [
+        {
+          "name": "Sergey Kushnarev"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.83,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.411"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Zwernemann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.300.355"
+      },
+      "instructors": [
+        {
+          "name": "Leonardo Lisi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.45,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.614"
+      },
+      "instructors": [
+        {
+          "name": "Steven Rokita"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.428"
+      },
+      "instructors": [
+        {
+          "name": "David Hovemeyer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.050.202"
+      },
+      "instructors": [
+        {
+          "name": "Kyle Rawlins"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.06,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.667"
+      },
+      "instructors": [
+        {
+          "name": "Philipp Koehn"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.65,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.010.245"
+      },
+      "instructors": [
+        {
+          "name": "Mitchell Merback"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.371.217"
+      },
+      "instructors": [
+        {
+          "name": "John Steck jr."
+        }
+      ],
+      "kind": "eval",
+      "score": 4.34,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.010.365"
+      },
+      "instructors": [
+        {
+          "name": "Lisa Deleonardis"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.010.373"
+      },
+      "instructors": [
+        {
+          "name": "Yinxing Liu"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.212.436"
+      },
+      "instructors": [
+        {
+          "name": "Elena Russo"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.010.467"
+      },
+      "instructors": [
+        {
+          "name": "Stephen Campbell"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.246"
+      },
+      "instructors": [
+        {
+          "name": "Jonathan Elliott"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.322"
+      },
+      "instructors": [
+        {
+          "name": "Kate Isaac"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.23,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.040.137"
+      },
+      "instructors": [
+        {
+          "name": "Emily Anderson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.26,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.060.336"
+      },
+      "instructors": [
+        {
+          "name": "Douglas Mao"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.7,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.337"
+      },
+      "instructors": [
+        {
+          "name": "Takashi Tsukamoto"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.65,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.389"
+      },
+      "instructors": [
+        {
+          "name": "Laura Mason"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.118"
+      },
+      "instructors": [
+        {
+          "name": "Rao Noor"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.85,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.210"
+      },
+      "instructors": [
+        {
+          "name": "Gregory Smaldone"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.218"
+      },
+      "instructors": [
+        {
+          "name": "Malaurie Pilatte"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.55,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.265"
+      },
+      "instructors": [
+        {
+          "name": "Vincenza Mazzeo"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.691"
+      },
+      "instructors": [
+        {
+          "name": "Hedy Alavi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.228"
+      },
+      "instructors": [
+        {
+          "name": "Taylor Stephens"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.388"
+      },
+      "instructors": [
+        {
+          "name": "Sasha Turner bryson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.372"
+      },
+      "instructors": [
+        {
+          "name": "Didier Gondola"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.130.154"
+      },
+      "instructors": [
+        {
+          "name": "Marie-lys Arnette"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.41,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.140.349"
+      },
+      "instructors": [
+        {
+          "name": "Filip Geaman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.23,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.145.321"
+      },
+      "instructors": [
+        {
+          "name": "Loren Ludwig"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.417"
+      },
+      "instructors": [
+        {
+          "name": "Lucy Allais"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.49,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.306"
+      },
+      "instructors": [
+        {
+          "name": "Bob Ross"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.306"
+      },
+      "instructors": [
+        {
+          "name": "Haiqing Zhao"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.306"
+      },
+      "instructors": [
+        {
+          "name": "Stewart Hendry"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.375"
+      },
+      "instructors": [
+        {
+          "name": "Justin Bledin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.332"
+      },
+      "instructors": [
+        {
+          "name": "Stelios Fourakis"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.41,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.392"
+      },
+      "instructors": [
+        {
+          "name": "Emel Filiz ozbay"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.310"
+      },
+      "instructors": [
+        {
+          "name": "Jacob Kripp"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.58,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.220"
+      },
+      "instructors": [
+        {
+          "name": "David Velleman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.74,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.432"
+      },
+      "instructors": [
+        {
+          "name": "Lester Spence"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.45,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.191.318"
+      },
+      "instructors": [
+        {
+          "name": "David Johnson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.61,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.191.343"
+      },
+      "instructors": [
+        {
+          "name": "Sheharyar Imran"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.56,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.314"
+      },
+      "instructors": [
+        {
+          "name": "Katie Tifft oshinnaiye"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.360.339"
+      },
+      "instructors": [
+        {
+          "name": "Jocelyne Diruggiero"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.192.316"
+      },
+      "instructors": [
+        {
+          "name": "Devesh Kapur"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.43,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.196.310"
+      },
+      "instructors": [
+        {
+          "name": "Peter Pomeranzev"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.196.310"
+      },
+      "instructors": [
+        {
+          "name": "Anne Applebaum"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.159"
+      },
+      "instructors": [
+        {
+          "name": "Howard Egeth"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.325"
+      },
+      "instructors": [
+        {
+          "name": "Dylan Selterman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.626"
+      },
+      "instructors": [
+        {
+          "name": "Xiongyi Huang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.487"
+      },
+      "instructors": [
+        {
+          "name": "Eileen Haase"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.74,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.213.332"
+      },
+      "instructors": [
+        {
+          "name": "Jennifer Gosetti"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.58,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.390"
+      },
+      "instructors": [
+        {
+          "name": "Tyler Derreth"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.215.430"
+      },
+      "instructors": [
+        {
+          "name": "William Egginton"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.46,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.215.452"
+      },
+      "instructors": [
+        {
+          "name": "Eduardo Gonzalez"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.78,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.215.452"
+      },
+      "instructors": [
+        {
+          "name": "Ryan Hill"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.71,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.301"
+      },
+      "instructors": [
+        {
+          "name": "Shannon Robinson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.660"
+      },
+      "instructors": [
+        {
+          "name": "David Yezzi"
+        }
+      ],
+      "kind": "eval",
+      "score": 2.8,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.300"
+      },
+      "instructors": [
+        {
+          "name": "Andrew Motion"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.49,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.650.658"
+      },
+      "instructors": [
+        {
+          "name": "Xiangyang Li"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.225.220"
+      },
+      "instructors": [
+        {
+          "name": "Abraham Stoll"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.275"
+      },
+      "instructors": [
+        {
+          "name": "Joel Andreas"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.334"
+      },
+      "instructors": [
+        {
+          "name": "Feinian Chen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.270.431"
+      },
+      "instructors": [
+        {
+          "name": "Daniel Viete"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.211.222"
+      },
+      "instructors": [
+        {
+          "name": "Bernadette Wegenstein"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.314"
+      },
+      "instructors": [
+        {
+          "name": "Moira Cahan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.308"
+      },
+      "instructors": [
+        {
+          "name": "Jason Trageser"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.100.115"
+      },
+      "instructors": [
+        {
+          "name": "Casey Lurtz"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.45,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.180.334"
+      },
+      "instructors": [
+        {
+          "name": "Jonathan Wright"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.99,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.173.111"
+      },
+      "instructors": [
+        {
+          "name": "Reid Mumford"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.89,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.173.111"
+      },
+      "instructors": [
+        {
+          "name": "Reid Mumford"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.97,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.173.111"
+      },
+      "instructors": [
+        {
+          "name": "Reid Mumford"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.304"
+      },
+      "instructors": [
+        {
+          "name": "Yi Li"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.46,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.361.100"
+      },
+      "instructors": [
+        {
+          "name": "Angelina Cotler"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.340"
+      },
+      "instructors": [
+        {
+          "name": "Conan Dickson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.340"
+      },
+      "instructors": [
+        {
+          "name": "John Colmers"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.362.335"
+      },
+      "instructors": [
+        {
+          "name": "Stuart Schrader"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.362.335"
+      },
+      "instructors": [
+        {
+          "name": "Heather Furnas"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.23,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.363.353"
+      },
+      "instructors": [
+        {
+          "name": "Cj Higgins"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.363.346"
+      },
+      "instructors": [
+        {
+          "name": "Joseph Plaster"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.367"
+      },
+      "instructors": [
+        {
+          "name": "Francesco Bianchi"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.370.116"
+      },
+      "instructors": [
+        {
+          "name": "Matthew Sampson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.371.184"
+      },
+      "instructors": [
+        {
+          "name": "Edgar Reyes"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.371.236"
+      },
+      "instructors": [
+        {
+          "name": "Sasha Baskin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.663"
+      },
+      "instructors": [
+        {
+          "name": "Jin Kim"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.52,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.613"
+      },
+      "instructors": [
+        {
+          "name": "Steven Rokita"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.81,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.625"
+      },
+      "instructors": [
+        {
+          "name": "James Arthur"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.240"
+      },
+      "instructors": [
+        {
+          "name": "Melissa Davey-rothwell"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.240"
+      },
+      "instructors": [
+        {
+          "name": "Karin Tobin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.240"
+      },
+      "instructors": [
+        {
+          "name": "Melissa Davey-rothwell"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.240"
+      },
+      "instructors": [
+        {
+          "name": "Karin Tobin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.650.614"
+      },
+      "instructors": [
+        {
+          "name": "Michael h Jacobs"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.470"
+      },
+      "instructors": [
+        {
+          "name": "Nick Meyerson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.15,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.311"
+      },
+      "instructors": [
+        {
+          "name": "Jason Fischer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.371.131"
+      },
+      "instructors": [
+        {
+          "name": "Tae Hwang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.371.131"
+      },
+      "instructors": [
+        {
+          "name": "Tae Hwang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.162"
+      },
+      "instructors": [
+        {
+          "name": "Deborah Mifflin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.162"
+      },
+      "instructors": [
+        {
+          "name": "Luke Beller"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.162"
+      },
+      "instructors": [
+        {
+          "name": "K\u00e4the Erichsen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.56,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.331"
+      },
+      "instructors": [
+        {
+          "name": "Sebastian Schmidt"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.07,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.362"
+      },
+      "instructors": [
+        {
+          "name": "Deborah Mifflin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.53,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.501.122"
+      },
+      "instructors": [
+        {
+          "name": "Dave Shade"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.66,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.391"
+      },
+      "instructors": [
+        {
+          "name": "Benjamin Chaffin"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.58,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.475"
+      },
+      "instructors": [
+        {
+          "name": "Simon Brown"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.34,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.510.662"
+      },
+      "instructors": [
+        {
+          "name": "Ken Livi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.216"
+      },
+      "instructors": [
+        {
+          "name": "Ralph Etienne cummings"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.510.652"
+      },
+      "instructors": [
+        {
+          "name": "Mitra Taheri"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.88,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.697"
+      },
+      "instructors": [
+        {
+          "name": "Ashutosh Dutta"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.638"
+      },
+      "instructors": [
+        {
+          "name": "Kevin Hemker"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.638"
+      },
+      "instructors": [
+        {
+          "name": "Syed Jalali"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.480"
+      },
+      "instructors": [
+        {
+          "name": "Joseph Greenstein"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.58,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.480"
+      },
+      "instructors": [
+        {
+          "name": "Casey Overby taylor"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.58,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.611"
+      },
+      "instructors": [
+        {
+          "name": "Soumya Acharya"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.59,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.530.666"
+      },
+      "instructors": [
+        {
+          "name": "Axel Krieger"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.658"
+      },
+      "instructors": [
+        {
+          "name": "Brandon Bukowski"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.46,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.767"
+      },
+      "instructors": [
+        {
+          "name": "Nicolas Loizou"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.794"
+      },
+      "instructors": [
+        {
+          "name": "Gregory Eyink"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.51,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.795"
+      },
+      "instructors": [
+        {
+          "name": "Zachary Lubberts"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.92,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.400"
+      },
+      "instructors": [
+        {
+          "name": "Illysa izenberg Izenberg"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.87,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.660.400"
+      },
+      "instructors": [
+        {
+          "name": "Sarah Smith"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.53,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.660.400"
+      },
+      "instructors": [
+        {
+          "name": "Richard Teague"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.76,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.161"
+      },
+      "instructors": [
+        {
+          "name": "Katherine Henry"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.151"
+      },
+      "instructors": [
+        {
+          "name": "Kathy Wilson"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.51,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.312"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Zwernemann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.46,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.312"
+      },
+      "instructors": [
+        {
+          "name": "Elizabeth Logsdon"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.41,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.312"
+      },
+      "instructors": [
+        {
+          "name": "Nicholas Durr"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.668"
+      },
+      "instructors": [
+        {
+          "name": "Hanzhang Lu"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.668"
+      },
+      "instructors": [
+        {
+          "name": "Vikram Chib"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.604"
+      },
+      "instructors": [
+        {
+          "name": "Rao Kosaraju"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.613"
+      },
+      "instructors": [
+        {
+          "name": "Krishan Sabnani"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.050.102"
+      },
+      "instructors": [
+        {
+          "name": "Julia Yarmolinskaya"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.646"
+      },
+      "instructors": [
+        {
+          "name": "Benjamin Langmead"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.392"
+      },
+      "instructors": [
+        {
+          "name": "Nusaybah Abu-mulaweh"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.392"
+      },
+      "instructors": [
+        {
+          "name": "Alissa Burkholder murphy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.613"
+      },
+      "instructors": [
+        {
+          "name": "Kevin Dungey"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.632"
+      },
+      "instructors": [
+        {
+          "name": "Muyinatu Bell"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.64,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.661"
+      },
+      "instructors": [
+        {
+          "name": "Kapil Katyal"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.74,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.661"
+      },
+      "instructors": [
+        {
+          "name": "Craig Jones"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.81,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.290.306"
+      },
+      "instructors": [
+        {
+          "name": "Amy Balanoff"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.290.490"
+      },
+      "instructors": [
+        {
+          "name": "Kirsten Bohn"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.290.490"
+      },
+      "instructors": [
+        {
+          "name": "Amy Balanoff"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.010.330"
+      },
+      "instructors": [
+        {
+          "name": "Unver Rustem"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.109"
+      },
+      "instructors": [
+        {
+          "name": "Fanjun Meng"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.83,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.109"
+      },
+      "instructors": [
+        {
+          "name": "Joseph Cutrone"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.109"
+      },
+      "instructors": [
+        {
+          "name": "Emily Braley"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.79,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.362.112"
+      },
+      "instructors": [
+        {
+          "name": "Shani Mott"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.362.112"
+      },
+      "instructors": [
+        {
+          "name": "Shani Mott"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.26,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.420"
+      },
+      "instructors": [
+        {
+          "name": "Heath Holt"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.420"
+      },
+      "instructors": [
+        {
+          "name": "Zachery Yeager"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.420"
+      },
+      "instructors": [
+        {
+          "name": "Michael Lieske"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.140"
+      },
+      "instructors": [
+        {
+          "name": "Linda Delibero"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.347"
+      },
+      "instructors": [
+        {
+          "name": "Trina Schroer"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.9,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.060.213"
+      },
+      "instructors": [
+        {
+          "name": "Jesse Rosenthal"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.060.213"
+      },
+      "instructors": [
+        {
+          "name": "Jeanne-marie Jackson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.060.347"
+      },
+      "instructors": [
+        {
+          "name": "Jared Hickman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.56,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.378.315"
+      },
+      "instructors": [
+        {
+          "name": "Makiko Nakao"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.080.333"
+      },
+      "instructors": [
+        {
+          "name": "Stewart Hendry"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.61,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.304"
+      },
+      "instructors": [
+        {
+          "name": "Arnold Bakker"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.52,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.303"
+      },
+      "instructors": [
+        {
+          "name": "Kyle Stine"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.99,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.441"
+      },
+      "instructors": [
+        {
+          "name": "Kevin Yarema"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.97,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.100.256"
+      },
+      "instructors": [
+        {
+          "name": "Pawel Maciejko"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.303"
+      },
+      "instructors": [
+        {
+          "name": "Michael Kwass"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.351"
+      },
+      "instructors": [
+        {
+          "name": "Barry Zirkin"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.79,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.180.333"
+      },
+      "instructors": [
+        {
+          "name": "Antonio Trujillo"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.83,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.371.126"
+      },
+      "instructors": [
+        {
+          "name": "Sasha Baskin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.378.396"
+      },
+      "instructors": [
+        {
+          "name": "Yuki Johnson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.540.635"
+      },
+      "instructors": [
+        {
+          "name": "Anastasia Georgiou"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.540.635"
+      },
+      "instructors": [
+        {
+          "name": "Yinong Zhao"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.74,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.211.224"
+      },
+      "instructors": [
+        {
+          "name": "Leonardo Proietti"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.214.225"
+      },
+      "instructors": [
+        {
+          "name": "Martina Franzini"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.214.225"
+      },
+      "instructors": [
+        {
+          "name": "Arielle Saiber"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.214.225"
+      },
+      "instructors": [
+        {
+          "name": "Samuel Zawacki"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.216.320"
+      },
+      "instructors": [
+        {
+          "name": "Neta Stahl"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.225.322"
+      },
+      "instructors": [
+        {
+          "name": "Margaret Denithorne"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.668"
+      },
+      "instructors": [
+        {
+          "name": "Lysley Tenorio"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.270.312"
+      },
+      "instructors": [
+        {
+          "name": "Siobhan Cooke"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.98,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.373.112"
+      },
+      "instructors": [
+        {
+          "name": "Nan Zhao"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.23,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.345"
+      },
+      "instructors": [
+        {
+          "name": "Derrick Wang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.113"
+      },
+      "instructors": [
+        {
+          "name": "Dimitrios Giovanis"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.500.113"
+      },
+      "instructors": [
+        {
+          "name": "John Edison"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.88,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.500.113"
+      },
+      "instructors": [
+        {
+          "name": "Leibny Garcia perera"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.75,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.500.113"
+      },
+      "instructors": [
+        {
+          "name": "Sathappan Ramesh"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.65,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.113"
+      },
+      "instructors": [
+        {
+          "name": "Scot Miller"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.113"
+      },
+      "instructors": [
+        {
+          "name": "John Edison"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.113"
+      },
+      "instructors": [
+        {
+          "name": "Corey Oses"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.113"
+      },
+      "instructors": [
+        {
+          "name": "Siamak Ardekani"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.54,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.113"
+      },
+      "instructors": [
+        {
+          "name": "Kwame Kutten"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.97,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.113"
+      },
+      "instructors": [
+        {
+          "name": "Kwame Kutten"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.004.302"
+      },
+      "instructors": [
+        {
+          "name": "Rebecca Wilbanks"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.52,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.374.102"
+      },
+      "instructors": [
+        {
+          "name": "Zachery Yeager"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.371.381"
+      },
+      "instructors": [
+        {
+          "name": "Margaret Murphy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.61,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.664"
+      },
+      "instructors": [
+        {
+          "name": "Musad Haque"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.683"
+      },
+      "instructors": [
+        {
+          "name": "Jin Kang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.52,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.425"
+      },
+      "instructors": [
+        {
+          "name": "Young Moon"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.58,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.621"
+      },
+      "instructors": [
+        {
+          "name": "Marc Donohue"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.453"
+      },
+      "instructors": [
+        {
+          "name": "Brooke Petty"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.360"
+      },
+      "instructors": [
+        {
+          "name": "Dani Smith"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.23,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.080.360"
+      },
+      "instructors": [
+        {
+          "name": "Jay Baraban"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.660.406"
+      },
+      "instructors": [
+        {
+          "name": "Illysa izenberg Izenberg"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.78,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.660.406"
+      },
+      "instructors": [
+        {
+          "name": "Sarah Smith"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.78,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.660.406"
+      },
+      "instructors": [
+        {
+          "name": "Richard Teague"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.52,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.329"
+      },
+      "instructors": [
+        {
+          "name": "Emily Fisher"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.329"
+      },
+      "instructors": [
+        {
+          "name": "Jocelyne Diruggiero"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.449"
+      },
+      "instructors": [
+        {
+          "name": "Sara Thoi"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.84,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.151"
+      },
+      "instructors": [
+        {
+          "name": "Rebecca Pearlman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.151"
+      },
+      "instructors": [
+        {
+          "name": "Richard Shingles"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.92,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.151"
+      },
+      "instructors": [
+        {
+          "name": "Christov Roberson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.151"
+      },
+      "instructors": [
+        {
+          "name": "Richard Shingles"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.61,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.301"
+      },
+      "instructors": [
+        {
+          "name": "Stephen Fried"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.09,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.050.353"
+      },
+      "instructors": [
+        {
+          "name": "Monica Lopez-gonzalez"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.99,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.040.126"
+      },
+      "instructors": [
+        {
+          "name": "Dimitrios Yatromanolakis"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.130.354"
+      },
+      "instructors": [
+        {
+          "name": "Michael Harrower"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.97,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.238"
+      },
+      "instructors": [
+        {
+          "name": "Floyd Norris"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.82,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.219"
+      },
+      "instructors": [
+        {
+          "name": "Karen Yasinsky"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.233"
+      },
+      "instructors": [
+        {
+          "name": "Jimmy Roche"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.336"
+      },
+      "instructors": [
+        {
+          "name": "Mohamed Farah"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.250.253"
+      },
+      "instructors": [
+        {
+          "name": "Jaime Sorenson"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.250.253"
+      },
+      "instructors": [
+        {
+          "name": "Jaime Sorenson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.253"
+      },
+      "instructors": [
+        {
+          "name": "Aaron Robinson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.63,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.465"
+      },
+      "instructors": [
+        {
+          "name": "Erin Cooney"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.300.305"
+      },
+      "instructors": [
+        {
+          "name": "Chris Taylor"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.290.330"
+      },
+      "instructors": [
+        {
+          "name": "Chris Kraft"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.85,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.348"
+      },
+      "instructors": [
+        {
+          "name": "William Rowe"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.413"
+      },
+      "instructors": [
+        {
+          "name": "John Marshall"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.201"
+      },
+      "instructors": [
+        {
+          "name": "Alexander Shumakovitch"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.201"
+      },
+      "instructors": [
+        {
+          "name": "Jonathan Weinberger"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.201"
+      },
+      "instructors": [
+        {
+          "name": "Nicholas Marshburn"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.78,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.201"
+      },
+      "instructors": [
+        {
+          "name": "Joseph Cutrone"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.64,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.201"
+      },
+      "instructors": [
+        {
+          "name": "Nicholas Marshburn"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.201"
+      },
+      "instructors": [
+        {
+          "name": "Julian Krolik"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.98,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.530.414"
+      },
+      "instructors": [
+        {
+          "name": "Dan Stoianovici"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.171.627"
+      },
+      "instructors": [
+        {
+          "name": "Colin Norman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.74,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.171.701"
+      },
+      "instructors": [
+        {
+          "name": "Marc Kamionkowski"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.171.703"
+      },
+      "instructors": [
+        {
+          "name": "Peter Armitage"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.21,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.180.355"
+      },
+      "instructors": [
+        {
+          "name": "Muhammad Husain"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.69,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.266"
+      },
+      "instructors": [
+        {
+          "name": "Josh Feinman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.84,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.080.305"
+      },
+      "instructors": [
+        {
+          "name": "Bob Ross"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.080.305"
+      },
+      "instructors": [
+        {
+          "name": "Haiqing Zhao"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.09,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.080.305"
+      },
+      "instructors": [
+        {
+          "name": "Christopher Fetsch"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.15,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.221"
+      },
+      "instructors": [
+        {
+          "name": "Kevin Yarema"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.221"
+      },
+      "instructors": [
+        {
+          "name": "Eileen Haase"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.9,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.221"
+      },
+      "instructors": [
+        {
+          "name": "Eun hyun Ahn"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.200.132"
+      },
+      "instructors": [
+        {
+          "name": "Lisa Feigenson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.200.322"
+      },
+      "instructors": [
+        {
+          "name": "Tyler Rickards"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.001.115"
+      },
+      "instructors": [
+        {
+          "name": "Howard Egeth"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.74,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.231"
+      },
+      "instructors": [
+        {
+          "name": "Sara More"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.001.141"
+      },
+      "instructors": [
+        {
+          "name": "Richard Brown"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.271.496"
+      },
+      "instructors": [
+        {
+          "name": "Jerry Burgess"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.061.267"
+      },
+      "instructors": [
+        {
+          "name": "Kyle Stine"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.74,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.520.241"
+      },
+      "instructors": [
+        {
+          "name": "Enrique Mallada garcia"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.421"
+      },
+      "instructors": [
+        {
+          "name": "Jeremy Brown"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.391"
+      },
+      "instructors": [
+        {
+          "name": "David Yezzi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.26,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.225.215"
+      },
+      "instructors": [
+        {
+          "name": "Margaret Denithorne"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.622"
+      },
+      "instructors": [
+        {
+          "name": "Honggang Cui"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.622"
+      },
+      "instructors": [
+        {
+          "name": "Kai Qi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.692"
+      },
+      "instructors": [
+        {
+          "name": "Rayanne Luke"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.391"
+      },
+      "instructors": [
+        {
+          "name": "Meredith Ward"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.69,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.650.640"
+      },
+      "instructors": [
+        {
+          "name": "Matthew Welling"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.225"
+      },
+      "instructors": [
+        {
+          "name": "Stan Becker"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.96,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.345"
+      },
+      "instructors": [
+        {
+          "name": "Margaret Taub"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.06,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.345"
+      },
+      "instructors": [
+        {
+          "name": "Leah Jager"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.06,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.355"
+      },
+      "instructors": [
+        {
+          "name": "Meghan Moran"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.97,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.355"
+      },
+      "instructors": [
+        {
+          "name": "Danetta Hendricks sloan"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.74,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.205"
+      },
+      "instructors": [
+        {
+          "name": "J d Tovar"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.63,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.030.205"
+      },
+      "instructors": [
+        {
+          "name": "Lawrence Principe"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.9,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.030.205"
+      },
+      "instructors": [
+        {
+          "name": "Christopher Falzone"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.8,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.030.205"
+      },
+      "instructors": [
+        {
+          "name": "Eric Hill"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.495"
+      },
+      "instructors": [
+        {
+          "name": "Peter Winch"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.48,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.374.101"
+      },
+      "instructors": [
+        {
+          "name": "Brandon Bangsboll"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.374.101"
+      },
+      "instructors": [
+        {
+          "name": "Megan Hale"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.660.419"
+      },
+      "instructors": [
+        {
+          "name": "Lawrence Aronhime"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.419"
+      },
+      "instructors": [
+        {
+          "name": "Alexander Cocron"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.360.624"
+      },
+      "instructors": [
+        {
+          "name": ""
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.510.314"
+      },
+      "instructors": [
+        {
+          "name": "Howard Katz"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.233"
+      },
+      "instructors": [
+        {
+          "name": "Lucas Buccafusca"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.39,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.380.101"
+      },
+      "instructors": [
+        {
+          "name": "Soo yun Kim"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.520.698"
+      },
+      "instructors": [
+        {
+          "name": "Yury Dvorkin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.465"
+      },
+      "instructors": [
+        {
+          "name": "Stavroula Sofou"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.530.618"
+      },
+      "instructors": [
+        {
+          "name": "Sung hoon Kang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.104"
+      },
+      "instructors": [
+        {
+          "name": "Tim Leschke"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.104"
+      },
+      "instructors": [
+        {
+          "name": "Tim Leschke"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.68,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.696"
+      },
+      "instructors": [
+        {
+          "name": "Joseph Moore"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.81,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.670.502"
+      },
+      "instructors": [
+        {
+          "name": "Hai-quan Mao"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.53,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.628"
+      },
+      "instructors": [
+        {
+          "name": "Honggang Cui"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.99,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.673"
+      },
+      "instructors": [
+        {
+          "name": "Michael Tsapatsis"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.627"
+      },
+      "instructors": [
+        {
+          "name": "Roza Galeeva"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.01,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.484"
+      },
+      "instructors": [
+        {
+          "name": "Michael Williams"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.410"
+      },
+      "instructors": [
+        {
+          "name": "Chuck Bennett"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.23,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.650"
+      },
+      "instructors": [
+        {
+          "name": "Donald Geman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.102"
+      },
+      "instructors": [
+        {
+          "name": "Claude Guillemard"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.56,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.102"
+      },
+      "instructors": [
+        {
+          "name": "Julianne Mehra"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.53,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.400"
+      },
+      "instructors": [
+        {
+          "name": "Andrew Motion"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.124"
+      },
+      "instructors": [
+        {
+          "name": "Monica Lopez-gonzalez"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.06,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.124"
+      },
+      "instructors": [
+        {
+          "name": "Monica Lopez-gonzalez"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.300.336"
+      },
+      "instructors": [
+        {
+          "name": "Yi-ping Ong"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.39,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.650.667"
+      },
+      "instructors": [
+        {
+          "name": "Tim Leschke"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.496"
+      },
+      "instructors": [
+        {
+          "name": "Russell Taylor"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.45,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.411"
+      },
+      "instructors": [
+        {
+          "name": "Julie Reiser"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.713"
+      },
+      "instructors": [
+        {
+          "name": "Denise Link-farajali"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.48,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.310"
+      },
+      "instructors": [
+        {
+          "name": "Brian Camley"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.68,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.215.380"
+      },
+      "instructors": [
+        {
+          "name": "Veronica Rios saavedra"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.211"
+      },
+      "instructors": [
+        {
+          "name": "Nathaniel Cornelius"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.211"
+      },
+      "instructors": [
+        {
+          "name": "Aaron Houston"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.103"
+      },
+      "instructors": [
+        {
+          "name": "Tobias Marriage"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.89,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.442"
+      },
+      "instructors": [
+        {
+          "name": "Subas Acharya"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.89,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.540.203"
+      },
+      "instructors": [
+        {
+          "name": "Efie Kokkoli"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.97,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.310"
+      },
+      "instructors": [
+        {
+          "name": "Jinchao Feng"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.69,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.310"
+      },
+      "instructors": [
+        {
+          "name": "Siqi Zhang"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.74,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.674"
+      },
+      "instructors": [
+        {
+          "name": "Siamak Ardekani"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.56,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.382"
+      },
+      "instructors": [
+        {
+          "name": "Alison Papadakis"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.76,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.201"
+      },
+      "instructors": [
+        {
+          "name": "Greg Williamson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.201"
+      },
+      "instructors": [
+        {
+          "name": "Landen Raszick"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.53,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.201"
+      },
+      "instructors": [
+        {
+          "name": "Greg Williamson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.45,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.201"
+      },
+      "instructors": [
+        {
+          "name": "David Yezzi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.662"
+      },
+      "instructors": [
+        {
+          "name": "Laurent Younes"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.79,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.754"
+      },
+      "instructors": [
+        {
+          "name": "Jess Dunleavey"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.45,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.754"
+      },
+      "instructors": [
+        {
+          "name": "Kevin Yarema"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.754"
+      },
+      "instructors": [
+        {
+          "name": "Jessica Dunleavey"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.34,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.754"
+      },
+      "instructors": [
+        {
+          "name": "Kevin Yarema"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.140.334"
+      },
+      "instructors": [
+        {
+          "name": "Yize Hu"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.204"
+      },
+      "instructors": [
+        {
+          "name": "Jane Bennett"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.270.353"
+      },
+      "instructors": [
+        {
+          "name": "Jerry Burgess"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.56,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.001.166"
+      },
+      "instructors": [
+        {
+          "name": "John Marshall"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.520.618"
+      },
+      "instructors": [
+        {
+          "name": "Mahyar Fazlyab"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.171.102"
+      },
+      "instructors": [
+        {
+          "name": "Petar Maksimovic"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.81,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.171.102"
+      },
+      "instructors": [
+        {
+          "name": "Surjeet Rajendran"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.656"
+      },
+      "instructors": [
+        {
+          "name": "Howard Weinert"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.304"
+      },
+      "instructors": [
+        {
+          "name": "Veit Stuphorn"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.329"
+      },
+      "instructors": [
+        {
+          "name": "Steven Marra"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.06,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.530.352"
+      },
+      "instructors": [
+        {
+          "name": "Kevin Hemker"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.530.648"
+      },
+      "instructors": [
+        {
+          "name": "Jill Middendorf"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.691"
+      },
+      "instructors": [
+        {
+          "name": "Jeremy Brown"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.530.721"
+      },
+      "instructors": [
+        {
+          "name": "Axel Krieger"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.371.130"
+      },
+      "instructors": [
+        {
+          "name": "John Steck jr."
+        }
+      ],
+      "kind": "eval",
+      "score": 4.26,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.444"
+      },
+      "instructors": [
+        {
+          "name": "Roza Galeeva"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.23,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.644"
+      },
+      "instructors": [
+        {
+          "name": "David Audley"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.730"
+      },
+      "instructors": [
+        {
+          "name": "Avanti Athreya"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.633"
+      },
+      "instructors": [
+        {
+          "name": "Jim Spall"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.43,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.510.601"
+      },
+      "instructors": [
+        {
+          "name": "Mingwei Chen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.520.232"
+      },
+      "instructors": [
+        {
+          "name": "Amy Foster"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.92,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.490"
+      },
+      "instructors": [
+        {
+          "name": "Dan Kuespert"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.68,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.540.490"
+      },
+      "instructors": [
+        {
+          "name": "Dan Kuespert"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.740"
+      },
+      "instructors": [
+        {
+          "name": "James Schmidt"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.243"
+      },
+      "instructors": [
+        {
+          "name": "Kwame Kutten"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.89,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.243"
+      },
+      "instructors": [
+        {
+          "name": "Michael Miller"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.81,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.001.159"
+      },
+      "instructors": [
+        {
+          "name": "Elizabeth Thornberry"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.52,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.658"
+      },
+      "instructors": [
+        {
+          "name": "Mihaela Pertea"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.723"
+      },
+      "instructors": [
+        {
+          "name": "Siamak Ardekani"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.371.153"
+      },
+      "instructors": [
+        {
+          "name": "Tae Hwang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.373.416"
+      },
+      "instructors": [
+        {
+          "name": "Shuyi Yang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.402"
+      },
+      "instructors": [
+        {
+          "name": "Heath Holt"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.402"
+      },
+      "instructors": [
+        {
+          "name": "Zachery Yeager"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.09,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.402"
+      },
+      "instructors": [
+        {
+          "name": "Michael Lieske"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.304"
+      },
+      "instructors": [
+        {
+          "name": "Jamie Spangler"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.07,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.650.601"
+      },
+      "instructors": [
+        {
+          "name": "Xiangyang Li"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.72,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.050.339"
+      },
+      "instructors": [
+        {
+          "name": "Julia Yarmolinskaya"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.98,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.479"
+      },
+      "instructors": [
+        {
+          "name": "Travis Rieder"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.145.312"
+      },
+      "instructors": [
+        {
+          "name": "Kamna Balhara"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.101"
+      },
+      "instructors": [
+        {
+          "name": "Ryan Calder"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.230.101"
+      },
+      "instructors": [
+        {
+          "name": "Andrew Perrin"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.8,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.101"
+      },
+      "instructors": [
+        {
+          "name": "Mike Reese"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.371.216"
+      },
+      "instructors": [
+        {
+          "name": "John Steck jr."
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.450"
+      },
+      "instructors": [
+        {
+          "name": "Robert Glaser"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.55,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.318"
+      },
+      "instructors": [
+        {
+          "name": "Ryan Huang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.76,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.311"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Zwernemann"
+        }
+      ],
+      "kind": "eval",
+      "score": 5.0,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.613"
+      },
+      "instructors": [
+        {
+          "name": "Sergey Kushnarev"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.001.112"
+      },
+      "instructors": [
+        {
+          "name": "Beatrice Lang"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.78,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.001.170"
+      },
+      "instructors": [
+        {
+          "name": "April Wuensch"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.560.305"
+      },
+      "instructors": [
+        {
+          "name": "Lucas De melo"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.9,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.470"
+      },
+      "instructors": [
+        {
+          "name": "Steve Hanke"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.52,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.488"
+      },
+      "instructors": [
+        {
+          "name": "Chris Bradburne"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.77,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.637"
+      },
+      "instructors": [
+        {
+          "name": "Deok-ho Kim"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.693"
+      },
+      "instructors": [
+        {
+          "name": "Web Stayman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.78,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.290"
+      },
+      "instructors": [
+        {
+          "name": "Joanne Selinski"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.426"
+      },
+      "instructors": [
+        {
+          "name": "Adam Charles"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.426"
+      },
+      "instructors": [
+        {
+          "name": "Kathleen Cullen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.426"
+      },
+      "instructors": [
+        {
+          "name": "Vikram Chib"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.46,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.426"
+      },
+      "instructors": [
+        {
+          "name": "Adrian Haith"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.370"
+      },
+      "instructors": [
+        {
+          "name": "Shadi Esnaashari"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.370"
+      },
+      "instructors": [
+        {
+          "name": "Jenna Frye"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.57,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.645"
+      },
+      "instructors": [
+        {
+          "name": "Amanda Hilliard"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.310.328"
+      },
+      "instructors": [
+        {
+          "name": "Andrea Worden"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.52,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.663.623"
+      },
+      "instructors": [
+        {
+          "name": "Denise Link-farajali"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.080.404"
+      },
+      "instructors": [
+        {
+          "name": "Jason Trageser"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.150"
+      },
+      "instructors": [
+        {
+          "name": "John Mann"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.88,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.061.150"
+      },
+      "instructors": [
+        {
+          "name": "John Mann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.445"
+      },
+      "instructors": [
+        {
+          "name": "John Marshall"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.304"
+      },
+      "instructors": [
+        {
+          "name": "Huajie Li"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.77,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.304"
+      },
+      "instructors": [
+        {
+          "name": "Nicholas Marshburn"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.419"
+      },
+      "instructors": [
+        {
+          "name": "Nagma Zerin"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.8,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.645"
+      },
+      "instructors": [
+        {
+          "name": "Jin Kim"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.040.216"
+      },
+      "instructors": [
+        {
+          "name": "Karen Ni mheallaigh"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.39,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.050.116"
+      },
+      "instructors": [
+        {
+          "name": "Donald Li"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.06,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.413"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Zwernemann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.41,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.413"
+      },
+      "instructors": [
+        {
+          "name": "Elizabeth Logsdon"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.080.339"
+      },
+      "instructors": [
+        {
+          "name": "Bob Ross"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.53,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.250"
+      },
+      "instructors": [
+        {
+          "name": "Sarah Pearsall"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.050.320"
+      },
+      "instructors": [
+        {
+          "name": "Geraldine Legendre"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.060.379"
+      },
+      "instructors": [
+        {
+          "name": "Jarvis Young"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.111"
+      },
+      "instructors": [
+        {
+          "name": "Shaun Spisak"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.82,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.482"
+      },
+      "instructors": [
+        {
+          "name": "William Rowe"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.39,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.231"
+      },
+      "instructors": [
+        {
+          "name": "Josh Feinman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.76,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.060.107"
+      },
+      "instructors": [
+        {
+          "name": "Sharon Achinstein"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.060.107"
+      },
+      "instructors": [
+        {
+          "name": "Mary Favret"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.491"
+      },
+      "instructors": [
+        {
+          "name": "Yannis Kevrekidis"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.510.429"
+      },
+      "instructors": [
+        {
+          "name": "Orla Wilson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.448"
+      },
+      "instructors": [
+        {
+          "name": "Andreas Andreou"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.46,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.420"
+      },
+      "instructors": [
+        {
+          "name": "David Kraemer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.540.630"
+      },
+      "instructors": [
+        {
+          "name": "Jeff Gray"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.291"
+      },
+      "instructors": [
+        {
+          "name": "Sergey Kushnarev"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.52,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.291"
+      },
+      "instructors": [
+        {
+          "name": "Mario Micheli"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.291"
+      },
+      "instructors": [
+        {
+          "name": "Prajakta purushottam Bedekar"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.291"
+      },
+      "instructors": [
+        {
+          "name": "Sergey Kushnarev"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.639"
+      },
+      "instructors": [
+        {
+          "name": "Kechen Zhang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.15,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.209"
+      },
+      "instructors": [
+        {
+          "name": "Chelsea Howe"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.315"
+      },
+      "instructors": [
+        {
+          "name": "Joe Forte"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.09,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.661.315"
+      },
+      "instructors": [
+        {
+          "name": "Joe Forte"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.315"
+      },
+      "instructors": [
+        {
+          "name": "Eric Rice"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.315"
+      },
+      "instructors": [
+        {
+          "name": "Trevor Mackesey"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.8,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.162"
+      },
+      "instructors": [
+        {
+          "name": "Rebecca Pearlman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.412"
+      },
+      "instructors": [
+        {
+          "name": "Fanjun Meng"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.406"
+      },
+      "instructors": [
+        {
+          "name": "Jeffrey Marino"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.87,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.140.317"
+      },
+      "instructors": [
+        {
+          "name": "Kristin Brig"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.176"
+      },
+      "instructors": [
+        {
+          "name": "Alessandro Zannirato"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.62,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.225.101"
+      },
+      "instructors": [
+        {
+          "name": "Gerrad Taylor"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.603"
+      },
+      "instructors": [
+        {
+          "name": "Nadia Zakamska"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.360.304"
+      },
+      "instructors": [
+        {
+          "name": "Tom Lippincott"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.360.304"
+      },
+      "instructors": [
+        {
+          "name": "Hale Sirin ryan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.360.304"
+      },
+      "instructors": [
+        {
+          "name": "Sam Backer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.360.304"
+      },
+      "instructors": [
+        {
+          "name": "Craig Messner"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.614"
+      },
+      "instructors": [
+        {
+          "name": "John Miller"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.72,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.310.107"
+      },
+      "instructors": [
+        {
+          "name": "Laura Reizman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.226"
+      },
+      "instructors": [
+        {
+          "name": "Patricio Simari"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.226"
+      },
+      "instructors": [
+        {
+          "name": "Ali Madooei"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.306"
+      },
+      "instructors": [
+        {
+          "name": "Katie Tifft oshinnaiye"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.87,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.306"
+      },
+      "instructors": [
+        {
+          "name": "Yumi Kim"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.83,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.334"
+      },
+      "instructors": [
+        {
+          "name": "Sophie Brady"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.403"
+      },
+      "instructors": [
+        {
+          "name": "Thomas Kempa"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.48,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.424"
+      },
+      "instructors": [
+        {
+          "name": "Stephen Fried"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.310"
+      },
+      "instructors": [
+        {
+          "name": "Alfredo Kirkwood"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.080.310"
+      },
+      "instructors": [
+        {
+          "name": "Hey-kyoung Lee"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.140.333"
+      },
+      "instructors": [
+        {
+          "name": "Robert Kargon"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.145.350"
+      },
+      "instructors": [
+        {
+          "name": "Alicia Puglionesi"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.83,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.070.345"
+      },
+      "instructors": [
+        {
+          "name": "Sabine Mohamed"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.57,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.101"
+      },
+      "instructors": [
+        {
+          "name": "Andrei Gritsan"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.7,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.070.284"
+      },
+      "instructors": [
+        {
+          "name": "Zeynel Gul"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.107"
+      },
+      "instructors": [
+        {
+          "name": "Tim Campion"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.66,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.107"
+      },
+      "instructors": [
+        {
+          "name": "Richard Brown"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.62,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.107"
+      },
+      "instructors": [
+        {
+          "name": "Sean Gruber"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.8,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.436"
+      },
+      "instructors": [
+        {
+          "name": "Elanor Taylor"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.53,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.351"
+      },
+      "instructors": [
+        {
+          "name": "Andrew Hoyt"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.180.371"
+      },
+      "instructors": [
+        {
+          "name": "Elena Krasnokutskaya"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.301"
+      },
+      "instructors": [
+        {
+          "name": "Erich Goldstein"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.63,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.410"
+      },
+      "instructors": [
+        {
+          "name": "Taekjip Ha"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.410"
+      },
+      "instructors": [
+        {
+          "name": "Sua Myong"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.39,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.380.202"
+      },
+      "instructors": [
+        {
+          "name": "Soo yun Kim"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.53,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.245"
+      },
+      "instructors": [
+        {
+          "name": "Andrew Stella"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.23,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.194.220"
+      },
+      "instructors": [
+        {
+          "name": "Homayra Ziad"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.09,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.301"
+      },
+      "instructors": [
+        {
+          "name": "Paul Hofer"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.57,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.301"
+      },
+      "instructors": [
+        {
+          "name": "Kristin Cook-gailloud"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.83,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.301"
+      },
+      "instructors": [
+        {
+          "name": "Kristin Cook-gailloud"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.301"
+      },
+      "instructors": [
+        {
+          "name": "Jean-ederson Jean-pierre"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.225.324"
+      },
+      "instructors": [
+        {
+          "name": "Joe Martin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.140.338"
+      },
+      "instructors": [
+        {
+          "name": "Alexander Parry"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.49,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.231"
+      },
+      "instructors": [
+        {
+          "name": "Katie Moulton"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.316"
+      },
+      "instructors": [
+        {
+          "name": "Steven Rokita"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.316"
+      },
+      "instructors": [
+        {
+          "name": "Sarah Woodson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.270.224"
+      },
+      "instructors": [
+        {
+          "name": "Darryn Waugh"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.88,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.270.224"
+      },
+      "instructors": [
+        {
+          "name": "Thomas Haine"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.365"
+      },
+      "instructors": [
+        {
+          "name": "Peter Beilenson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.300.102"
+      },
+      "instructors": [
+        {
+          "name": "Paola Marrati"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.693"
+      },
+      "instructors": [
+        {
+          "name": "Mario Micheli"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.39,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.301"
+      },
+      "instructors": [
+        {
+          "name": "Dani Smith"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.401"
+      },
+      "instructors": [
+        {
+          "name": "Alexander Shumakovitch"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.401"
+      },
+      "instructors": [
+        {
+          "name": "Nicholas Marshburn"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.371.303"
+      },
+      "instructors": [
+        {
+          "name": "Christiana Caro"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.371.219"
+      },
+      "instructors": [
+        {
+          "name": "John Steck jr."
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.250"
+      },
+      "instructors": [
+        {
+          "name": "Samuel Burt"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.01,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.570.698"
+      },
+      "instructors": [
+        {
+          "name": "Shere Abbott"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.380.302"
+      },
+      "instructors": [
+        {
+          "name": "Soo yun Kim"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.070.118"
+      },
+      "instructors": [
+        {
+          "name": "Valeria Procupez"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.26,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.070.289"
+      },
+      "instructors": [
+        {
+          "name": "Veena Das"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.92,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.070.328"
+      },
+      "instructors": [
+        {
+          "name": "Niloofar Haeri"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.060.326"
+      },
+      "instructors": [
+        {
+          "name": "Sharon Achinstein"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.46,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.134.101"
+      },
+      "instructors": [
+        {
+          "name": "Ted Lewis"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.230"
+      },
+      "instructors": [
+        {
+          "name": "Pedro Irazoqui"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.97,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.004.263"
+      },
+      "instructors": [
+        {
+          "name": "George Oppel"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.15,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.520.142"
+      },
+      "instructors": [
+        {
+          "name": "Lucas Buccafusca"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.371.152"
+      },
+      "instructors": [
+        {
+          "name": "Htet San"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.53,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.243"
+      },
+      "instructors": [
+        {
+          "name": "David Kraemer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.344"
+      },
+      "instructors": [
+        {
+          "name": "Steven Marra"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.58,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.192.150"
+      },
+      "instructors": [
+        {
+          "name": "Adria Lawrence"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.540.618"
+      },
+      "instructors": [
+        {
+          "name": "Sangmoo Jeong"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.510.610"
+      },
+      "instructors": [
+        {
+          "name": "Peter Searson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.636"
+      },
+      "instructors": [
+        {
+          "name": "Tamas Budavari"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.636"
+      },
+      "instructors": [
+        {
+          "name": "Tamas Budavari"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.560.250"
+      },
+      "instructors": [
+        {
+          "name": "Yakov Zelickman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.711"
+      },
+      "instructors": [
+        {
+          "name": "Joseph Greenstein"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.23,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.711"
+      },
+      "instructors": [
+        {
+          "name": "Patrick Kanold"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.681"
+      },
+      "instructors": [
+        {
+          "name": "Mario Micheli"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.101"
+      },
+      "instructors": [
+        {
+          "name": "Dylan Selterman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.1,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.200.101"
+      },
+      "instructors": [
+        {
+          "name": "Dylan Selterman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.560.362"
+      },
+      "instructors": [
+        {
+          "name": "Jochen Mueller"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.560.392"
+      },
+      "instructors": [
+        {
+          "name": "Rachel Sangree"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.74,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.326"
+      },
+      "instructors": [
+        {
+          "name": "Mohamed Farah"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.622"
+      },
+      "instructors": [
+        {
+          "name": "Mohammad ali Darvish darab"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.87,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.244"
+      },
+      "instructors": [
+        {
+          "name": "Michael Beer"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.66,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.657"
+      },
+      "instructors": [
+        {
+          "name": "Lawrence Aronhime"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.657"
+      },
+      "instructors": [
+        {
+          "name": "Alexander Cocron"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.010.364"
+      },
+      "instructors": [
+        {
+          "name": "Marian Feldman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.211.303"
+      },
+      "instructors": [
+        {
+          "name": "Rochelle Tobias"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.54,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.230"
+      },
+      "instructors": [
+        {
+          "name": "Sara More"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.6,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.230"
+      },
+      "instructors": [
+        {
+          "name": "Sara More"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.68,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.445"
+      },
+      "instructors": [
+        {
+          "name": "Ryan Calder"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.330"
+      },
+      "instructors": [
+        {
+          "name": "Cara Mcnamara"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.503"
+      },
+      "instructors": [
+        {
+          "name": "Ali Madooei"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.385"
+      },
+      "instructors": [
+        {
+          "name": "Lawrence Aronhime"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.57,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.385"
+      },
+      "instructors": [
+        {
+          "name": "Alexander Cocron"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.57,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.335"
+      },
+      "instructors": [
+        {
+          "name": "Megan Latshaw"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.97,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.335"
+      },
+      "instructors": [
+        {
+          "name": "Joseph Bressler"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.92,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.335"
+      },
+      "instructors": [
+        {
+          "name": "Megan Latshaw"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.75,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.335"
+      },
+      "instructors": [
+        {
+          "name": "Joseph Bressler"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.73,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.382"
+      },
+      "instructors": [
+        {
+          "name": "Trevor Mackesey"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.57,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.377"
+      },
+      "instructors": [
+        {
+          "name": "Anna Coppola"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.228"
+      },
+      "instructors": [
+        {
+          "name": "Eric Hill"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.07,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.200"
+      },
+      "instructors": [
+        {
+          "name": "Jeffrey Bowen"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.71,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.311"
+      },
+      "instructors": [
+        {
+          "name": "Arancha Hubbard"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.311"
+      },
+      "instructors": [
+        {
+          "name": "Maria Sanchez paraiso"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.134"
+      },
+      "instructors": [
+        {
+          "name": "Misha Rubanov"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.73,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.134"
+      },
+      "instructors": [
+        {
+          "name": "Misha Rubanov"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.49,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.334"
+      },
+      "instructors": [
+        {
+          "name": "Paul Ferraro"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.363"
+      },
+      "instructors": [
+        {
+          "name": "Carolyn Norris"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.59,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.363"
+      },
+      "instructors": [
+        {
+          "name": "Mark Van doren"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.76,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.305"
+      },
+      "instructors": [
+        {
+          "name": "Vincent Hilser"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.83,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.305"
+      },
+      "instructors": [
+        {
+          "name": "Katie Tifft oshinnaiye"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.9,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.305"
+      },
+      "instructors": [
+        {
+          "name": "Katie Tifft oshinnaiye"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.305"
+      },
+      "instructors": [
+        {
+          "name": "Christov Roberson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.305"
+      },
+      "instructors": [
+        {
+          "name": "Robert Horner"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.74,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.040.208"
+      },
+      "instructors": [
+        {
+          "name": "Giacomo Loi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.632"
+      },
+      "instructors": [
+        {
+          "name": "Jung-hee Seo"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.88,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.441"
+      },
+      "instructors": [
+        {
+          "name": "Christopher Falzone"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.76,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.464"
+      },
+      "instructors": [
+        {
+          "name": "Musad Haque"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.82,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.671"
+      },
+      "instructors": [
+        {
+          "name": "Daniel Khashabi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.62,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.303"
+      },
+      "instructors": [
+        {
+          "name": "Sean Furlong"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.41,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.380"
+      },
+      "instructors": [
+        {
+          "name": "Shadi Esnaashari"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.41,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.396"
+      },
+      "instructors": [
+        {
+          "name": "Jules Gill peterson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.62,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.118"
+      },
+      "instructors": [
+        {
+          "name": "Peter Achinstein"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.84,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.438"
+      },
+      "instructors": [
+        {
+          "name": "Benjamin Ginsberg"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.466"
+      },
+      "instructors": [
+        {
+          "name": "Savannah Brenneke"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.64,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.172.601"
+      },
+      "instructors": [
+        {
+          "name": "Daniel Reich"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.173.308"
+      },
+      "instructors": [
+        {
+          "name": "Oleg Tchernyshyov"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.73,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.612"
+      },
+      "instructors": [
+        {
+          "name": "Edward Hedgecock"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.81,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.229"
+      },
+      "instructors": [
+        {
+          "name": "David Hovemeyer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.229"
+      },
+      "instructors": [
+        {
+          "name": "David Hovemeyer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.623"
+      },
+      "instructors": [
+        {
+          "name": "Umesh Korde"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.405"
+      },
+      "instructors": [
+        {
+          "name": "Lan Cheng"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.54,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.499"
+      },
+      "instructors": [
+        {
+          "name": "Jason Trageser"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.61,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.499"
+      },
+      "instructors": [
+        {
+          "name": "Susanne Sterbing-d'angelo"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.54,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.499"
+      },
+      "instructors": [
+        {
+          "name": "Bob Ross"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.57,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.499"
+      },
+      "instructors": [
+        {
+          "name": "Dani Smith"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.59,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.225.310"
+      },
+      "instructors": [
+        {
+          "name": "William Roche"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.626"
+      },
+      "instructors": [
+        {
+          "name": "Bruce Snider"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.341"
+      },
+      "instructors": [
+        {
+          "name": "Emily Agree"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.98,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.230.341"
+      },
+      "instructors": [
+        {
+          "name": "Emily Agree"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.77,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.205"
+      },
+      "instructors": [
+        {
+          "name": "Patrick Connolly"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.210"
+      },
+      "instructors": [
+        {
+          "name": "Giovanna maria dora Dore"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.39,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.501.123"
+      },
+      "instructors": [
+        {
+          "name": "Randal Burns"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.499"
+      },
+      "instructors": [
+        {
+          "name": "Peter Winch"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.72,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.501.119"
+      },
+      "instructors": [
+        {
+          "name": "Mia Russell"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.110.125"
+      },
+      "instructors": [
+        {
+          "name": "Alexa Gaines"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.07,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.180"
+      },
+      "instructors": [
+        {
+          "name": "Pj Brendese"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.82,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.145.320"
+      },
+      "instructors": [
+        {
+          "name": "Christine Slobogin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.57,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.356"
+      },
+      "instructors": [
+        {
+          "name": "David Goldberg"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.110"
+      },
+      "instructors": [
+        {
+          "name": "Jonathan Flombaum"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.202"
+      },
+      "instructors": [
+        {
+          "name": "Meredith Greif"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.380"
+      },
+      "instructors": [
+        {
+          "name": "Peter Winch"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.41,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.252"
+      },
+      "instructors": [
+        {
+          "name": "Ian Sims"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.77,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.787"
+      },
+      "instructors": [
+        {
+          "name": "Anqi Liu"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.124"
+      },
+      "instructors": [
+        {
+          "name": "Ishan Barman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.87,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.010.400"
+      },
+      "instructors": [
+        {
+          "name": "Aaron Hyman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.540.307"
+      },
+      "instructors": [
+        {
+          "name": "Nagma Zerin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.409"
+      },
+      "instructors": [
+        {
+          "name": "Bruce Anderson"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.97,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.361"
+      },
+      "instructors": [
+        {
+          "name": "Donniell Fishkind"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.361"
+      },
+      "instructors": [
+        {
+          "name": "Konstantinos Pantazis"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.65,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.120"
+      },
+      "instructors": [
+        {
+          "name": "Zachery Yeager"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.250"
+      },
+      "instructors": [
+        {
+          "name": "Sue Conley"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.96,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.250"
+      },
+      "instructors": [
+        {
+          "name": "Leslie Kendrick"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.77,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.666"
+      },
+      "instructors": [
+        {
+          "name": "David Yarowsky"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.106"
+      },
+      "instructors": [
+        {
+          "name": "Mia Russell"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.607"
+      },
+      "instructors": [
+        {
+          "name": "Eric Rice"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.612"
+      },
+      "instructors": [
+        {
+          "name": "Soumyadipta Acharya"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.34,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.510.316"
+      },
+      "instructors": [
+        {
+          "name": "Hai-quan Mao"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.640"
+      },
+      "instructors": [
+        {
+          "name": "Andreas Andreou"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.640"
+      },
+      "instructors": [
+        {
+          "name": "Daniel Mendat"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.606"
+      },
+      "instructors": [
+        {
+          "name": "Ryan Hurley"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.41,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.622"
+      },
+      "instructors": [
+        {
+          "name": "Joseph Katz"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.212"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Zwernemann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.56,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.212"
+      },
+      "instructors": [
+        {
+          "name": "Constanza Miranda mendoza"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.51,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.212"
+      },
+      "instructors": [
+        {
+          "name": "Elizabeth Logsdon"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.51,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.212"
+      },
+      "instructors": [
+        {
+          "name": "Nicholas Durr"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.51,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.114"
+      },
+      "instructors": [
+        {
+          "name": "Simon Brown"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.412"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Zwernemann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.49,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.412"
+      },
+      "instructors": [
+        {
+          "name": "Elizabeth Logsdon"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.48,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.412"
+      },
+      "instructors": [
+        {
+          "name": "Nicholas Durr"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.362.318"
+      },
+      "instructors": [
+        {
+          "name": "Minkah Makalani"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.45,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.312"
+      },
+      "instructors": [
+        {
+          "name": "Edward Hedgecock"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.73,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.340"
+      },
+      "instructors": [
+        {
+          "name": "Carolyn Norris"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.13,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.340"
+      },
+      "instructors": [
+        {
+          "name": "Carolyn Norris"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.340"
+      },
+      "instructors": [
+        {
+          "name": "Carolyn Norris"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.442"
+      },
+      "instructors": [
+        {
+          "name": "Rebecca Pearlman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.442"
+      },
+      "instructors": [
+        {
+          "name": "Richard Shingles"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.402"
+      },
+      "instructors": [
+        {
+          "name": "Gregory Quiroz"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.402"
+      },
+      "instructors": [
+        {
+          "name": "Paraj Titum"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.43,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.196.201"
+      },
+      "instructors": [
+        {
+          "name": "Hahrie Han"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.196.201"
+      },
+      "instructors": [
+        {
+          "name": "Lily Mason"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.275"
+      },
+      "instructors": [
+        {
+          "name": "Flavia De azeredo cerqueira"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.49,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.275"
+      },
+      "instructors": [
+        {
+          "name": "Benjamin Chaffin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.54,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.215.231"
+      },
+      "instructors": [
+        {
+          "name": "Alexis Hernando cubas"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.14,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.215.231"
+      },
+      "instructors": [
+        {
+          "name": "Eduardo Gonzalez"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.21,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.215.231"
+      },
+      "instructors": [
+        {
+          "name": "Rachel Williams"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.23,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.371.133"
+      },
+      "instructors": [
+        {
+          "name": "Margaret Murphy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.371.133"
+      },
+      "instructors": [
+        {
+          "name": "Barbara Gruber"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.371.133"
+      },
+      "instructors": [
+        {
+          "name": "Margaret Murphy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.653"
+      },
+      "instructors": [
+        {
+          "name": "Beryl Castello"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.98,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.672"
+      },
+      "instructors": [
+        {
+          "name": "Drg Gnang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.7,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.389.250"
+      },
+      "instructors": [
+        {
+          "name": "Jennifer Jarvis"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.335"
+      },
+      "instructors": [
+        {
+          "name": "Fadil Santosa"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.764"
+      },
+      "instructors": [
+        {
+          "name": "Kenton Murray"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.54,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.123"
+      },
+      "instructors": [
+        {
+          "name": "Najim Dehak"
+        }
+      ],
+      "kind": "eval",
+      "score": 2.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.410"
+      },
+      "instructors": [
+        {
+          "name": "Eileen Haase"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.69,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.010.355"
+      },
+      "instructors": [
+        {
+          "name": "Caroline Schopp"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.41,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.050.206"
+      },
+      "instructors": [
+        {
+          "name": "Julia Yarmolinskaya"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.060.430"
+      },
+      "instructors": [
+        {
+          "name": "Lawrence Jackson"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.91,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.303"
+      },
+      "instructors": [
+        {
+          "name": "David Kaplan"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.99,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.171.612"
+      },
+      "instructors": [
+        {
+          "name": "Julian Krolik"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.332"
+      },
+      "instructors": [
+        {
+          "name": "Christopher Honey"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.336"
+      },
+      "instructors": [
+        {
+          "name": "Bob Barbera"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.211"
+      },
+      "instructors": [
+        {
+          "name": "Naiara Martinez-velez"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.34,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.211"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Tracy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.23,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.111"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Tracy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.210.111"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Tracy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.262"
+      },
+      "instructors": [
+        {
+          "name": "Heidi Wheeler"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.107"
+      },
+      "instructors": [
+        {
+          "name": "Morris Swartz"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.171.107"
+      },
+      "instructors": [
+        {
+          "name": "Reid Mumford"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.73,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.327"
+      },
+      "instructors": [
+        {
+          "name": "Rui Ni"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.230.352"
+      },
+      "instructors": [
+        {
+          "name": "Huei-ying Kuo"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.120"
+      },
+      "instructors": [
+        {
+          "name": "Philip Leaf"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.75,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.380.102"
+      },
+      "instructors": [
+        {
+          "name": "Soo yun Kim"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.411"
+      },
+      "instructors": [
+        {
+          "name": "Lawrence Aronhime"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.88,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.411"
+      },
+      "instructors": [
+        {
+          "name": "Anton Dahbura"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.85,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.499"
+      },
+      "instructors": [
+        {
+          "name": "Yitzhak Melamed"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.254"
+      },
+      "instructors": [
+        {
+          "name": "Anna Goodridge"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.2,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.530.254"
+      },
+      "instructors": [
+        {
+          "name": "Anna Goodridge"
+        }
+      ],
+      "kind": "eval",
+      "score": 2.83,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.687"
+      },
+      "instructors": [
+        {
+          "name": "Sathappan Ramesh"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.39,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.560.636"
+      },
+      "instructors": [
+        {
+          "name": "Santiago Bonetti"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.59,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.248"
+      },
+      "instructors": [
+        {
+          "name": "Joel Bader"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.45,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.414"
+      },
+      "instructors": [
+        {
+          "name": "Soudeh Ghorbani khaledi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.09,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.650.624"
+      },
+      "instructors": [
+        {
+          "name": "Reuben Johnston"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.650.631"
+      },
+      "instructors": [
+        {
+          "name": "Lanier Watkins"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.010.458"
+      },
+      "instructors": [
+        {
+          "name": "Catherine Popovici"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.72,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.373.212"
+      },
+      "instructors": [
+        {
+          "name": "Aiguo Chen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.300.307"
+      },
+      "instructors": [
+        {
+          "name": "Paula Mendes"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.92,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.480"
+      },
+      "instructors": [
+        {
+          "name": "Yun Chen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.212.353"
+      },
+      "instructors": [
+        {
+          "name": "April Wuensch"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.48,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.212.353"
+      },
+      "instructors": [
+        {
+          "name": "April Wuensch"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.54,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.212.353"
+      },
+      "instructors": [
+        {
+          "name": "Julia Jacob"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.58,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.205"
+      },
+      "instructors": [
+        {
+          "name": "Adam Rodgers"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.205"
+      },
+      "instructors": [
+        {
+          "name": "Russell Sharman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.202"
+      },
+      "instructors": [
+        {
+          "name": "Manon Page"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.202"
+      },
+      "instructors": [
+        {
+          "name": "Suzanne Roos"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.202"
+      },
+      "instructors": [
+        {
+          "name": "Camille Roche"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.202"
+      },
+      "instructors": [
+        {
+          "name": "Thomas D'amato"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.58,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.212"
+      },
+      "instructors": [
+        {
+          "name": "Naiara Martinez-velez"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.212"
+      },
+      "instructors": [
+        {
+          "name": "Grecia Chirinos delgado"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.41,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.212"
+      },
+      "instructors": [
+        {
+          "name": "Maria Sanchez paraiso"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.48,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.210.212"
+      },
+      "instructors": [
+        {
+          "name": "Rosario Ramos"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.316"
+      },
+      "instructors": [
+        {
+          "name": "Tarak Barkawi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.319"
+      },
+      "instructors": [
+        {
+          "name": "Steven Teles"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.46,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.372"
+      },
+      "instructors": [
+        {
+          "name": "Doug Barrick"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.64,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.323"
+      },
+      "instructors": [
+        {
+          "name": "Ryan Calder"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.641"
+      },
+      "instructors": [
+        {
+          "name": "John Miller"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.666"
+      },
+      "instructors": [
+        {
+          "name": "Sanjeev Khudanpur"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.451"
+      },
+      "instructors": [
+        {
+          "name": "Yana Safonova"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.96,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.010.474"
+      },
+      "instructors": [
+        {
+          "name": "Jennifer Stager"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.231"
+      },
+      "instructors": [
+        {
+          "name": "Pedro Irazoqui"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.72,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.191.334"
+      },
+      "instructors": [
+        {
+          "name": "Kathleen Frydl"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.64,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.202"
+      },
+      "instructors": [
+        {
+          "name": "Sakul Ratanalert"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.540.202"
+      },
+      "instructors": [
+        {
+          "name": "Nagma Zerin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.334"
+      },
+      "instructors": [
+        {
+          "name": "Claire Hur"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.454"
+      },
+      "instructors": [
+        {
+          "name": "Jessica Dunleavey"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.79,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.454"
+      },
+      "instructors": [
+        {
+          "name": "Winston Timp"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.75,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.140.106"
+      },
+      "instructors": [
+        {
+          "name": "Nathaniel Comfort"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.352"
+      },
+      "instructors": [
+        {
+          "name": "Michael Agronin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.01,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.100.426"
+      },
+      "instructors": [
+        {
+          "name": "John Marshall"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.118"
+      },
+      "instructors": [
+        {
+          "name": "Adam Riess"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.118"
+      },
+      "instructors": [
+        {
+          "name": "Wei Zheng"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.07,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.622"
+      },
+      "instructors": [
+        {
+          "name": "Daniel Beller"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.050.203"
+      },
+      "instructors": [
+        {
+          "name": "Mick Bonner"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.7,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.398"
+      },
+      "instructors": [
+        {
+          "name": "William Connolly"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.362.140"
+      },
+      "instructors": [
+        {
+          "name": "Jasmine Blanks jones"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.231"
+      },
+      "instructors": [
+        {
+          "name": "Suhnne Ahn"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.84,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.270.114"
+      },
+      "instructors": [
+        {
+          "name": "David Sing"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.63,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.001.181"
+      },
+      "instructors": [
+        {
+          "name": "Jacek Mostwin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.510.403"
+      },
+      "instructors": [
+        {
+          "name": "Patty Mcguiggan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.34,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.540.637"
+      },
+      "instructors": [
+        {
+          "name": "Marc Ostermeier"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.314"
+      },
+      "instructors": [
+        {
+          "name": "Stephen Farias"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.314"
+      },
+      "instructors": [
+        {
+          "name": "Lilian Josephson"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.314"
+      },
+      "instructors": [
+        {
+          "name": "David Gracias"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.263"
+      },
+      "instructors": [
+        {
+          "name": "Greg Duffee"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.84,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.317"
+      },
+      "instructors": [
+        {
+          "name": "Steve Drigotas"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.68,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.205"
+      },
+      "instructors": [
+        {
+          "name": "Ana Damjanovic"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.250.205"
+      },
+      "instructors": [
+        {
+          "name": "Maria Procopio"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.250.205"
+      },
+      "instructors": [
+        {
+          "name": "Maria Procopio"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.205"
+      },
+      "instructors": [
+        {
+          "name": "Ana Damjanovic"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.616"
+      },
+      "instructors": [
+        {
+          "name": "Hugh Ellis"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.09,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.290.101"
+      },
+      "instructors": [
+        {
+          "name": "Amy Balanoff"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.88,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.652"
+      },
+      "instructors": [
+        {
+          "name": "Konstantinos Konstantopoulos"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.603"
+      },
+      "instructors": [
+        {
+          "name": "Soumyadipta Acharya"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.221"
+      },
+      "instructors": [
+        {
+          "name": "Joshua Fishbein"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.381.102"
+      },
+      "instructors": [
+        {
+          "name": "Radhi Datla"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.766"
+      },
+      "instructors": [
+        {
+          "name": "Amitabh Basu"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.607"
+      },
+      "instructors": [
+        {
+          "name": "Ben Hobbs"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.55,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.414"
+      },
+      "instructors": [
+        {
+          "name": "Annette Leps"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.656"
+      },
+      "instructors": [
+        {
+          "name": "Russell Taylor"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.59,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.691"
+      },
+      "instructors": [
+        {
+          "name": "Maia Stiber"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.85,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.650.672"
+      },
+      "instructors": [
+        {
+          "name": "Yingchuan Zhang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.626"
+      },
+      "instructors": [
+        {
+          "name": "Subas Acharya"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.640"
+      },
+      "instructors": [
+        {
+          "name": "Herman Goodyear"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.48,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.424"
+      },
+      "instructors": [
+        {
+          "name": "John Ratnanather"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.81,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.424"
+      },
+      "instructors": [
+        {
+          "name": "Eileen Haase"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.96,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.424"
+      },
+      "instructors": [
+        {
+          "name": "Connor Pyles"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.97,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.424"
+      },
+      "instructors": [
+        {
+          "name": "Xiaoqin Wang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.424"
+      },
+      "instructors": [
+        {
+          "name": "Patrick Kanold"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.06,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.153"
+      },
+      "instructors": [
+        {
+          "name": "Rebecca Pearlman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.88,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.638"
+      },
+      "instructors": [
+        {
+          "name": "Adam Charles"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.691"
+      },
+      "instructors": [
+        {
+          "name": "Reza Shadmehr"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.650.654"
+      },
+      "instructors": [
+        {
+          "name": "Xiangyang Li"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.34,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.675"
+      },
+      "instructors": [
+        {
+          "name": "Raman Arora"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.9,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.601"
+      },
+      "instructors": [
+        {
+          "name": "Rigoberto Hernandez"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.130.177"
+      },
+      "instructors": [
+        {
+          "name": "Michael Harrower"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.375"
+      },
+      "instructors": [
+        {
+          "name": "Lauren Ross"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.322"
+      },
+      "instructors": [
+        {
+          "name": "Robert Lieberman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.07,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.442"
+      },
+      "instructors": [
+        {
+          "name": "Sunita Thyagarajan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.211.316"
+      },
+      "instructors": [
+        {
+          "name": "Flavia De azeredo cerqueira"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.105"
+      },
+      "instructors": [
+        {
+          "name": "Maria Procopio"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.93,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.105"
+      },
+      "instructors": [
+        {
+          "name": "Linda Delibero"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.105"
+      },
+      "instructors": [
+        {
+          "name": "Annette Porter"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.97,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.436"
+      },
+      "instructors": [
+        {
+          "name": "Tamas Budavari"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.436"
+      },
+      "instructors": [
+        {
+          "name": "Tamas Budavari"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.79,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.657"
+      },
+      "instructors": [
+        {
+          "name": "Hugh Ellis"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.333"
+      },
+      "instructors": [
+        {
+          "name": "Mia Russell"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.308"
+      },
+      "instructors": [
+        {
+          "name": "Gueter Aurelien"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.133"
+      },
+      "instructors": [
+        {
+          "name": "Steve Drigotas"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.83,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.200.133"
+      },
+      "instructors": [
+        {
+          "name": "Steve Drigotas"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.88,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.666"
+      },
+      "instructors": [
+        {
+          "name": "Mia Russell"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.116"
+      },
+      "instructors": [
+        {
+          "name": "Steven Marra"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.389.202"
+      },
+      "instructors": [
+        {
+          "name": "Robert Forloney"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.302"
+      },
+      "instructors": [
+        {
+          "name": "Brandon Bangsboll"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.302"
+      },
+      "instructors": [
+        {
+          "name": "Shaun Stoner"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.53,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.374.302"
+      },
+      "instructors": [
+        {
+          "name": "Zachery Yeager"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.230.150"
+      },
+      "instructors": [
+        {
+          "name": "Christy Thornton"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.270.317"
+      },
+      "instructors": [
+        {
+          "name": "Jerry Burgess"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.48,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.414"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Zwernemann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.414"
+      },
+      "instructors": [
+        {
+          "name": "Elizabeth Logsdon"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.220"
+      },
+      "instructors": [
+        {
+          "name": "Mohammad ali Darvish darab"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.12,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.601.220"
+      },
+      "instructors": [
+        {
+          "name": "David Hovemeyer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.220"
+      },
+      "instructors": [
+        {
+          "name": "Mohammad ali Darvish darab"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.220"
+      },
+      "instructors": [
+        {
+          "name": "Juan Barragan"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.220"
+      },
+      "instructors": [
+        {
+          "name": "David Hovemeyer"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.346"
+      },
+      "instructors": [
+        {
+          "name": "Nusaybah Abu-mulaweh"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.346"
+      },
+      "instructors": [
+        {
+          "name": "Alissa Burkholder murphy"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.346"
+      },
+      "instructors": [
+        {
+          "name": "Jenna Frye"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.45,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.497"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Zwernemann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.316"
+      },
+      "instructors": [
+        {
+          "name": "Robert Horner"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.96,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.337"
+      },
+      "instructors": [
+        {
+          "name": "Barry Zirkin"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.9,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.194.205"
+      },
+      "instructors": [
+        {
+          "name": "Homayra Ziad"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.112"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Zwernemann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.46,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.112"
+      },
+      "instructors": [
+        {
+          "name": "Constanza Miranda mendoza"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.112"
+      },
+      "instructors": [
+        {
+          "name": "Elizabeth Logsdon"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.43,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.112"
+      },
+      "instructors": [
+        {
+          "name": "Nicholas Durr"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.211"
+      },
+      "instructors": [
+        {
+          "name": "Chikako Mese"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.83,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.106"
+      },
+      "instructors": [
+        {
+          "name": "Danielle Speller"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.69,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.334"
+      },
+      "instructors": [
+        {
+          "name": "Calvin Terbeek"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.664"
+      },
+      "instructors": [
+        {
+          "name": "Jeremias Sulam"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.671"
+      },
+      "instructors": [
+        {
+          "name": "Bill Smedick"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.79,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.212.334"
+      },
+      "instructors": [
+        {
+          "name": "Elena Russo"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.4,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.050.105"
+      },
+      "instructors": [
+        {
+          "name": "Michael Mccloskey"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.9,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.295"
+      },
+      "instructors": [
+        {
+          "name": "Mario Micheli"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.49,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.510.311"
+      },
+      "instructors": [
+        {
+          "name": "Dingchang Lin"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.87,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.442"
+      },
+      "instructors": [
+        {
+          "name": "Warren Grayson"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.91,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.580.442"
+      },
+      "instructors": [
+        {
+          "name": "Jennifer Elisseeff"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.660.105"
+      },
+      "instructors": [
+        {
+          "name": "Illysa Izenberg"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.105"
+      },
+      "instructors": [
+        {
+          "name": "Rob Murray"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.707"
+      },
+      "instructors": [
+        {
+          "name": "Simon Leonard"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.681"
+      },
+      "instructors": [
+        {
+          "name": "Chao Wang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.44,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.683"
+      },
+      "instructors": [
+        {
+          "name": "Rachel Karchin"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.676"
+      },
+      "instructors": [
+        {
+          "name": "Sascha Cocron"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.663.676"
+      },
+      "instructors": [
+        {
+          "name": "David Long"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.645"
+      },
+      "instructors": [
+        {
+          "name": "David Audley"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.0,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.408"
+      },
+      "instructors": [
+        {
+          "name": "Michelle Zwernemann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.34,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.408"
+      },
+      "instructors": [
+        {
+          "name": "Elizabeth Logsdon"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.3,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.660.340"
+      },
+      "instructors": [
+        {
+          "name": "Joshua Reiter"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.140.302"
+      },
+      "instructors": [
+        {
+          "name": "Lijing Jiang"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.0,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.140.302"
+      },
+      "instructors": [
+        {
+          "name": "Alison Mcmanus"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.783"
+      },
+      "instructors": [
+        {
+          "name": "Alan Yuille"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.96,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.402"
+      },
+      "instructors": [
+        {
+          "name": "Anna Coppola"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.52,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.302"
+      },
+      "instructors": [
+        {
+          "name": "Kit Bowen"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.7,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.526"
+      },
+      "instructors": [
+        {
+          "name": "Thomas Lectka"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.321"
+      },
+      "instructors": [
+        {
+          "name": "Jason Trageser"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.200"
+      },
+      "instructors": [
+        {
+          "name": "Kate Keleher"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.200"
+      },
+      "instructors": [
+        {
+          "name": "Kate Keleher"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.55,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.200"
+      },
+      "instructors": [
+        {
+          "name": "Katie Moulton"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.300"
+      },
+      "instructors": [
+        {
+          "name": "Cara Cummings"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.83,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.106"
+      },
+      "instructors": [
+        {
+          "name": "Jamie Young"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.25,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.106"
+      },
+      "instructors": [
+        {
+          "name": "Jamie Young"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.48,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.171.702"
+      },
+      "instructors": [
+        {
+          "name": "Marc Kamionkowski"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.51,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.241"
+      },
+      "instructors": [
+        {
+          "name": "Somasree Dasgupta"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.347"
+      },
+      "instructors": [
+        {
+          "name": "Margaret Taub"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.45,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.620"
+      },
+      "instructors": [
+        {
+          "name": "Fred Torcaso"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.26,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.620"
+      },
+      "instructors": [
+        {
+          "name": "Fred Torcaso"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.22,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.648"
+      },
+      "instructors": [
+        {
+          "name": "Trac duy Tran"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.01,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.615"
+      },
+      "instructors": [
+        {
+          "name": "John Goutsias"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.111"
+      },
+      "instructors": [
+        {
+          "name": "Aseel Titi"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.66,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.553.420"
+      },
+      "instructors": [
+        {
+          "name": "Fred Torcaso"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.553.420"
+      },
+      "instructors": [
+        {
+          "name": "Fred Torcaso"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.212"
+      },
+      "instructors": [
+        {
+          "name": "J d Tovar"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.48,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.328"
+      },
+      "instructors": [
+        {
+          "name": "Dani Smith"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.196.301"
+      },
+      "instructors": [
+        {
+          "name": "Scott Warren"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.302"
+      },
+      "instructors": [
+        {
+          "name": "Kate Keleher"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.54,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.225.323"
+      },
+      "instructors": [
+        {
+          "name": "William Roche"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.738"
+      },
+      "instructors": [
+        {
+          "name": "Andreas Andreou"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.53,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.445"
+      },
+      "instructors": [
+        {
+          "name": "Sina Hazratpour"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.361"
+      },
+      "instructors": [
+        {
+          "name": "Somasree Dasgupta"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.250.310"
+      },
+      "instructors": [
+        {
+          "name": "Ananya Majumdar"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.640"
+      },
+      "instructors": [
+        {
+          "name": "Feilim Mac gabhann"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.42,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.215"
+      },
+      "instructors": [
+        {
+          "name": "Vicky Nguyen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.353"
+      },
+      "instructors": [
+        {
+          "name": "Ciaran Harman"
+        }
+      ],
+      "kind": "eval",
+      "score": 2.83,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.421"
+      },
+      "instructors": [
+        {
+          "name": "Ciaran Harman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.94,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.421"
+      },
+      "instructors": [
+        {
+          "name": "Harihar Rajaram"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.421"
+      },
+      "instructors": [
+        {
+          "name": "Hedy Alavi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.1,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.101"
+      },
+      "instructors": [
+        {
+          "name": "Kenneth Karlin"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.25,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.030.101"
+      },
+      "instructors": [
+        {
+          "name": "Joel Tolman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.53,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.030.101"
+      },
+      "instructors": [
+        {
+          "name": "Sunita Thyagarajan"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.89,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.378.116"
+      },
+      "instructors": [
+        {
+          "name": "Rena Naganuma"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.64,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.378.116"
+      },
+      "instructors": [
+        {
+          "name": "Yuki Johnson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.63,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.601.621"
+      },
+      "instructors": [
+        {
+          "name": "Ali Madooei"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.250"
+      },
+      "instructors": [
+        {
+          "name": "Jason Heiserman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.17,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.661.250"
+      },
+      "instructors": [
+        {
+          "name": "Andy Ross"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.41,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.250"
+      },
+      "instructors": [
+        {
+          "name": "Kevin Dungey"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.250"
+      },
+      "instructors": [
+        {
+          "name": "Julie Reiser"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.69,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.250"
+      },
+      "instructors": [
+        {
+          "name": "Joshua Reiter"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.52,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.250"
+      },
+      "instructors": [
+        {
+          "name": "Sarah Smith"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.250"
+      },
+      "instructors": [
+        {
+          "name": "Jason Heiserman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.661.250"
+      },
+      "instructors": [
+        {
+          "name": "Andy Ross"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.190.379"
+      },
+      "instructors": [
+        {
+          "name": "Matthew Kocher"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.192.210"
+      },
+      "instructors": [
+        {
+          "name": "Yunshan Ye"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.7,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.350"
+      },
+      "instructors": [
+        {
+          "name": "Michael Schneider"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.350"
+      },
+      "instructors": [
+        {
+          "name": "Heather Mckay"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.04,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.350"
+      },
+      "instructors": [
+        {
+          "name": "Michael Schneider"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.350"
+      },
+      "instructors": [
+        {
+          "name": "Heather Mckay"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.280.101"
+      },
+      "instructors": [
+        {
+          "name": "Maria Bulzacchelli"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.07,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.280.101"
+      },
+      "instructors": [
+        {
+          "name": "Maria Bulzacchelli"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.84,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.380.402"
+      },
+      "instructors": [
+        {
+          "name": "Soo yun Kim"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.6,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.570.448"
+      },
+      "instructors": [
+        {
+          "name": "Josh Weiss"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.58,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.644"
+      },
+      "instructors": [
+        {
+          "name": "Kevin Yarema"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.06,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.622"
+      },
+      "instructors": [
+        {
+          "name": "Xiongyi Huang"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.96,
+      "summary": "",
+      "term": "Intersession",
+      "year": "Intersession:2023"
+    },
+    {
+      "course": {
+        "code": "AS.050.325"
+      },
+      "instructors": [
+        {
+          "name": "Colin Wilson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.340"
+      },
+      "instructors": [
+        {
+          "name": "Debby Haskins"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.54,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.061.152"
+      },
+      "instructors": [
+        {
+          "name": "Jimmy Roche"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.18,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.250"
+      },
+      "instructors": [
+        {
+          "name": "Jason Trageser"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.24,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.080.250"
+      },
+      "instructors": [
+        {
+          "name": "Susanne Sterbing-d'angelo"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.080.250"
+      },
+      "instructors": [
+        {
+          "name": "Bob Ross"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.21,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.080.250"
+      },
+      "instructors": [
+        {
+          "name": "Jason Trageser"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.250"
+      },
+      "instructors": [
+        {
+          "name": "Susanne Sterbing-d'angelo"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.080.250"
+      },
+      "instructors": [
+        {
+          "name": "Bob Ross"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.311"
+      },
+      "instructors": [
+        {
+          "name": "Yifu Zhou"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.71,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.301"
+      },
+      "instructors": [
+        {
+          "name": "Yannis Kevrekidis"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.301"
+      },
+      "instructors": [
+        {
+          "name": "Thi Vo"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.71,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.150.219"
+      },
+      "instructors": [
+        {
+          "name": "Hilary Bok"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.12,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.020.152"
+      },
+      "instructors": [
+        {
+          "name": "Rebecca Pearlman"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.86,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.152"
+      },
+      "instructors": [
+        {
+          "name": "Richard Shingles"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.8,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.152"
+      },
+      "instructors": [
+        {
+          "name": "Christov Roberson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.152"
+      },
+      "instructors": [
+        {
+          "name": "Richard Shingles"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.06,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.070.402"
+      },
+      "instructors": [
+        {
+          "name": "Anand Pandian"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.63,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.070.402"
+      },
+      "instructors": [
+        {
+          "name": "Shashawnda Campbell"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.66,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.370.115"
+      },
+      "instructors": [
+        {
+          "name": "Matthew Sampson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.36,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "EN.520.692"
+      },
+      "instructors": [
+        {
+          "name": "Philippe Pouliquen"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.03,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.681"
+      },
+      "instructors": [
+        {
+          "name": "Joseph Greenstein"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.620"
+      },
+      "instructors": [
+        {
+          "name": "John Toscano"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.5,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.410"
+      },
+      "instructors": [
+        {
+          "name": "Sean Sun"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.08,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.020.154"
+      },
+      "instructors": [
+        {
+          "name": "Rebecca Pearlman"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.02,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.413"
+      },
+      "instructors": [
+        {
+          "name": "Ashwin Iyengar"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.16,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.110.413"
+      },
+      "instructors": [
+        {
+          "name": "Lauren Ross"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.43,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.173.112"
+      },
+      "instructors": [
+        {
+          "name": "Reid Mumford"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.07,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.173.112"
+      },
+      "instructors": [
+        {
+          "name": "Reid Mumford"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.99,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.173.112"
+      },
+      "instructors": [
+        {
+          "name": "Reid Mumford"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.173.116"
+      },
+      "instructors": [
+        {
+          "name": "Reid Mumford"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.41,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.378.416"
+      },
+      "instructors": [
+        {
+          "name": "Rena Naganuma"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.68,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.306"
+      },
+      "instructors": [
+        {
+          "name": "Yayuan Liu"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.19,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.114"
+      },
+      "instructors": [
+        {
+          "name": "David Kraemer"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.75,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.623"
+      },
+      "instructors": [
+        {
+          "name": "Jerry Prince"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.520.617"
+      },
+      "instructors": [
+        {
+          "name": "Howard Weinert"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.102"
+      },
+      "instructors": [
+        {
+          "name": "Sunita Thyagarajan"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.47,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.030.102"
+      },
+      "instructors": [
+        {
+          "name": "Jamie Young"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.47,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "AS.180.301"
+      },
+      "instructors": [
+        {
+          "name": "Sohani Fatehin"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.87,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Chase Atherton"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.95,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Megan Robinson"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.34,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Kate Keleher"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.43,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Caroline Wray"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.37,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Dylan Carpenter"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.2,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Brianna Steidle"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.29,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Kosisochukwu Ugwueze"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.33,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Katy Gathright"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.27,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Eric Emmons"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.28,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Melissa Cook"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.98,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Hye ji Choi"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.38,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Regan Green"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.35,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Josiah Cox"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.31,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.220.106"
+      },
+      "instructors": [
+        {
+          "name": "Kate Keleher"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.64,
+      "summary": "",
+      "term": "Summer",
+      "year": "Summer:2023"
+    },
+    {
+      "course": {
+        "code": "EN.530.216"
+      },
+      "instructors": [
+        {
+          "name": "Steven Marra"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.65,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.540.645"
+      },
+      "instructors": [
+        {
+          "name": "Marc Donohue"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.67,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.307"
+      },
+      "instructors": [
+        {
+          "name": "Danielle Ploetz"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.11,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.376.222"
+      },
+      "instructors": [
+        {
+          "name": "Joshua Fishbein"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.92,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.560.601"
+      },
+      "instructors": [
+        {
+          "name": "Dimitrios Giovanis"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.14,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "AS.200.141"
+      },
+      "instructors": [
+        {
+          "name": "Bob Ross"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.32,
+      "summary": "",
+      "term": "Fall",
+      "year": "Fall:2022"
+    },
+    {
+      "course": {
+        "code": "AS.200.141"
+      },
+      "instructors": [
+        {
+          "name": "Dani Smith"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.05,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.580.743"
+      },
+      "instructors": [
+        {
+          "name": "Alexis Battle"
+        }
+      ],
+      "kind": "eval",
+      "score": 4.66,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    },
+    {
+      "course": {
+        "code": "EN.500.115"
+      },
+      "instructors": [
+        {
+          "name": "Siamak Ardekani"
+        }
+      ],
+      "kind": "eval",
+      "score": 3.84,
+      "summary": "",
+      "term": "Spring",
+      "year": "Spring:2023"
+    }
+  ],
+  "$meta": {
+    "$schools": {
+      "jhu": {}
+    }
+  }
+}


### PR DESCRIPTION
## Description
- The evaluation parsing script `parsing/library/evals_parser.py` is added.
- The resultant JSON file from the script containing readily digestable evaluations is added.
- `build/run_parser.sh` is modified to digest evaluations from `parsing/schools/jhu/data/evals.json` automatically everyday.

## Future Work
- Currently, the script checks all ~16,000 courses for available evaluations in a specified year. We can change this in the future to check only the courses offered in a particular year or semester for available evaluations, which can save time.