### PR TITLE
Fix incorrect time zone for last updated time

### DIFF
--- a/manifests/prod/cronjob.yml
+++ b/manifests/prod/cronjob.yml
@@ -14,7 +14,7 @@ spec:
           containers:
             - image: semesterly.azurecr.io/semesterly:Version
               name: gunicorn-cron
-              command: ["/bin/bash","/code/run_parser.sh"]
+              command: ["/bin/bash", "/code/run_parser.sh"]
               workingDir: /code
               envFrom:
                 - secretRef:

--- a/static/js/redux/ui/Semesterly.tsx
+++ b/static/js/redux/ui/Semesterly.tsx
@@ -128,7 +128,7 @@ const Semesterly = () => {
     // DataLastUpdated Input example-  2021-05-02 14:42 UTC
     // Params: How the backend sends a timestamp
     // dateString: of the form yyyy-mm-dd hh:mm
-    const dateString = dataLastUpdated.toString().slice(0, -4); // exclude UTC
+    const dateString = dataLastUpdated.toString();
 
     if (!dateString || dateString.length === 0) return "";
 


### PR DESCRIPTION
## Description
The `Data Last Updated` shown on bottom left of the app has been wrong the whole time because the cron job runs in UTC time but the timezone info was chopped off from the time string causing the displayed time to actually be the UTC time instead of the local time that it says.
![image](https://github.com/jhuopensource/semesterly/assets/37493948/6c29aadd-856b-4ab0-84ee-73708514cd72)
The above `20:21:00` is the UTC time and NOT the pacific time
