### PR TITLE
fix: edited date last updated so that the displayed day of the month …

### DIFF
--- a/static/js/redux/ui/Semesterly.tsx
+++ b/static/js/redux/ui/Semesterly.tsx
@@ -174,9 +174,7 @@ const Semesterly = () => {
 
     const monthIndex: number = curDate.getMonth();
 
-    return `${
-      months[monthIndex]
-    } ${curDay}${dayEnding}, ${curDate.getFullYear()}`;
+    return `${months[monthIndex]} ${curDay}${dayEnding}, ${curDate.getFullYear()}`;
   };
 
   const mobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(

--- a/static/js/redux/ui/Semesterly.tsx
+++ b/static/js/redux/ui/Semesterly.tsx
@@ -153,7 +153,7 @@ const Semesterly = () => {
     ];
 
     let dayEnding: String;
-    const curDay = curDate.getDay();
+    const curDay = curDate.getUTCDate();
     if (curDay >= 11 && curDay <= 13) {
       dayEnding = "th";
     }
@@ -176,7 +176,7 @@ const Semesterly = () => {
 
     return `${
       months[monthIndex]
-    } ${curDate.getUTCDate()}${dayEnding}, ${curDate.getFullYear()}`;
+    } ${curDay}${dayEnding}, ${curDate.getFullYear()}`;
   };
 
   const mobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(


### PR DESCRIPTION
…and the day used to determine the day-suffix match.

Small error previously where using getDate() and getUTCDate() would return different day values, causing a mismatch in displayed date vs. suffix (i.e. "January 3th" instead of "4th")