### PR TITLE
bugfix: fixed kitawesome icons and updated current/former members

### DIFF
--- a/agreement/templates/privacypolicy.html
+++ b/agreement/templates/privacypolicy.html
@@ -44,7 +44,7 @@
 		ga('send', 'pageview');
 	</script>
 
-	<script src="https://kit.fontawesome.com/54815f8287.js" crossorigin="anonymous"></script>
+	<script src="https://kit.fontawesome.com/2ab9935212.js" crossorigin="anonymous"></script>
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 	<script src="https://malsup.github.io/jquery.cycle2.js"></script>
 	<script type='text/javascript' src='/static/js/course-page.js'></script>

--- a/agreement/templates/termsofservice.html
+++ b/agreement/templates/termsofservice.html
@@ -44,7 +44,7 @@
 		ga('send', 'pageview');
 	</script>
 
-	<script src="https://kit.fontawesome.com/54815f8287.js" crossorigin="anonymous"></script>
+	<script src="https://kit.fontawesome.com/2ab9935212.js" crossorigin="anonymous"></script>
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 	<script src="https://malsup.github.io/jquery.cycle2.js"></script>
 	<script type='text/javascript' src='/static/js/course-page.js'></script>

--- a/parsing/schools/jhu/data/courses.json:Zone.Identifier
+++ b/parsing/schools/jhu/data/courses.json:Zone.Identifier
@@ -1,0 +1,3 @@
+[ZoneTransfer]
+ZoneId=3
+HostUrl=https://cdn.discordapp.com/attachments/1071257322392928298/1202418167113060362/courses.json?ex=65cd622e&is=65baed2e&hm=cf03408b250ae5eacaecbb9402c5264f1e9015d48eeebcf1c5c615fcd2ca94e4&

--- a/parsing/schools/jhu/data/courses.json:Zone.Identifier
+++ b/parsing/schools/jhu/data/courses.json:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://cdn.discordapp.com/attachments/1071257322392928298/1202418167113060362/courses.json?ex=65cd622e&is=65baed2e&hm=cf03408b250ae5eacaecbb9402c5264f1e9015d48eeebcf1c5c615fcd2ca94e4&

--- a/semesterly/templates/about.html
+++ b/semesterly/templates/about.html
@@ -33,7 +33,7 @@
 	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
 		integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
 
-	<script src="https://kit.fontawesome.com/54815f8287.js" crossorigin="anonymous"></script>
+	<script src="https://kit.fontawesome.com/2ab9935212.js" crossorigin="anonymous"></script>
 	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 	<script type="text/javascript" src="{% static 'js/splash.js'%}"></script>
 
@@ -149,28 +149,6 @@
 						</div>
 					</div>
 					<div class="col-1-3 member">
-						<div class="circular" style="background-image: url(/static/img/jessie.png)"></div>
-						<h4 class="name">Jessie Luo</h4>
-						<h3>Software Engineer - FullStack</h3>
-						<h3>JHU '24</h3>
-						<div class="social">
-							<a href="https://github.com/JessieLuo30"><i class="fab fa-github fa-2x"></i></a>
-							<a href="https://www.linkedin.com/in/jessie-luo-bc076/"><i
-							class="fab fa-linkedin fa-2x"></i></a>
-						</div>
-					</div>
-					<div class="col-1-3 member">
-						<div class="circular" style="background-image: url(/static/img/andreasjaramillo.jpg)"></div>
-						<h4 class="name">Andreas Jaramillo</h4>
-						<h3>Software Engineer - FullStack</h3>
-						<h3>JHU '26</h3>
-						<div class="social">
-							<a href="https://github.com/andyjaramillo"><i class="fab fa-github fa-2x"></i></a>
-							<a href="https://www.linkedin.com/in/andreas-jaramillo/"><i
-									class="fab fa-linkedin fa-2x"></i></a>
-						</div>
-					</div>
-					<div class="col-1-3 member">
 						<div class="circular" style="background-image: url(/static/img/spencerhuang.png)"></div>
 						<h4 class="name">Spencer Huang</h4>
 						<h3>Software Engineer - FullStack</h3>
@@ -182,18 +160,6 @@
 						</div>
 					</div>
 					<div class="col-1-3 member">
-						<div class="circular" style="background-image: url(/static/img/kirondeb.jpg)"></div>
-						<h4 class="name">Kiron Deb</h4>
-						<h3>Software Engineer - Frontend</h3>
-						<h3>JHU '25</h3>
-						<div class="social">
-							<a href="/"><i class="fa fa-fw fa-link fa-2x"></i></a>
-							<a href="https://github.com/K02D"><i class="fab fa-github fa-2x"></i></a>
-							<a href="https://www.linkedin.com/in/kiron-deb-2aa4a4163/"><i
-									class="fab fa-linkedin fa-2x"></i></a>
-						</div>
-					</div>
-					<div class="col-1-3 member">
 						<div class="circular" style="background-image: url(/static/img/jiashucopy.jpg)"></div>
 						<h4 class="name">Jiashu Yang</h4>
 						<h3>Software Engineer - FullStack</h3>
@@ -201,17 +167,6 @@
 						<div class="social">
 							<a href="https://github.com/jyang0403"><i class="fab fa-github fa-2x"></i></a>
 							<a href="https://www.linkedin.com/in/jiashu-yang/"><i
-									class="fab fa-linkedin fa-2x"></i></a>
-						</div>
-					</div>
-					<div class="col-1-3 member">
-						<div class="circular" style="background-image: url(/static/img/jerrychen.jpg)"></div>
-						<h4 class="name">Jiarui Chen</h4>
-						<h3>Software Engineer - FullStack</h3>
-						<h3>JHU '24</h3>
-						<div class="social">
-							<a href="https://github.com/jchen324"><i class="fab fa-github fa-2x"></i></a>
-							<a href="https://www.linkedin.com/in/jiarui-chen/"><i 
 									class="fab fa-linkedin fa-2x"></i></a>
 						</div>
 					</div>
@@ -271,6 +226,51 @@
 						<div class="social">
 							<a href="https://github.com/JJamesWWang"><i class="fab fa-github fa-2x"></i></a>
 							<a href="https://www.linkedin.com/in/jjameswwang/"><i
+									class="fab fa-linkedin fa-2x"></i></a>
+						</div>
+					</div>
+					<div class="col-1-4 member">
+						<div class="circular" style="background-image: url(/static/img/kirondeb.jpg)"></div>
+						<h4 class="name">Kiron Deb</h4>
+						<h3>Software Engineer - Frontend</h3>
+						<h3>JHU '25</h3>
+						<div class="social">
+							<a href="/"><i class="fa fa-fw fa-link fa-2x"></i></a>
+							<a href="https://github.com/K02D"><i class="fab fa-github fa-2x"></i></a>
+							<a href="https://www.linkedin.com/in/kiron-deb-2aa4a4163/"><i
+									class="fab fa-linkedin fa-2x"></i></a>
+						</div>
+					</div>
+					<div class="col-1-4 member">
+						<div class="circular" style="background-image: url(/static/img/jerrychen.jpg)"></div>
+						<h4 class="name">Jiarui Chen</h4>
+						<h3>Software Engineer - FullStack</h3>
+						<h3>JHU '24</h3>
+						<div class="social">
+							<a href="https://github.com/jchen324"><i class="fab fa-github fa-2x"></i></a>
+							<a href="https://www.linkedin.com/in/jiarui-chen/"><i 
+									class="fab fa-linkedin fa-2x"></i></a>
+						</div>
+					</div>
+					<div class="col-1-4 member">
+						<div class="circular" style="background-image: url(/static/img/jessie.png)"></div>
+						<h4 class="name">Jessie Luo</h4>
+						<h3>Software Engineer - FullStack</h3>
+						<h3>JHU '24</h3>
+						<div class="social">
+							<a href="https://github.com/JessieLuo30"><i class="fab fa-github fa-2x"></i></a>
+							<a href="https://www.linkedin.com/in/jessie-luo-bc076/"><i
+							class="fab fa-linkedin fa-2x"></i></a>
+						</div>
+					</div>
+					<div class="col-1-4 member">
+						<div class="circular" style="background-image: url(/static/img/andreasjaramillo.jpg)"></div>
+						<h4 class="name">Andreas Jaramillo</h4>
+						<h3>Software Engineer - FullStack</h3>
+						<h3>JHU '26</h3>
+						<div class="social">
+							<a href="https://github.com/andyjaramillo"><i class="fab fa-github fa-2x"></i></a>
+							<a href="https://www.linkedin.com/in/andreas-jaramillo/"><i
 									class="fab fa-linkedin fa-2x"></i></a>
 						</div>
 					</div>

--- a/semesterly/templates/notice.html
+++ b/semesterly/templates/notice.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.3/css/fontawesome.min.css"
         integrity="sha384-wESLQ85D6gbsF459vf1CiZ2+rr+CsxRY0RpiF1tLlQpDnAgg6rwdsUF1+Ics2bni" crossorigin="anonymous">
-    <script src="https://kit.fontawesome.com/54815f8287.js" crossorigin="anonymous"></script>
+    <script src="https://kit.fontawesome.com/2ab9935212.js" crossorigin="anonymous"></script>
 </head>
 
 <body>

--- a/timetable/templates/header.html
+++ b/timetable/templates/header.html
@@ -21,7 +21,7 @@
 	<link rel="stylesheet"
 		href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.3/css/fontawesome.min.css"
 		integrity="sha384-wESLQ85D6gbsF459vf1CiZ2+rr+CsxRY0RpiF1tLlQpDnAgg6rwdsUF1+Ics2bni" crossorigin="anonymous">
-	<script src="https://kit.fontawesome.com/54815f8287.js" crossorigin="anonymous"></script>
+	<script src="https://kit.fontawesome.com/2ab9935212.js" crossorigin="anonymous"></script>
 
 	{% block css_block %}{% endblock %}
 	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"

--- a/timetable/templates/index.html
+++ b/timetable/templates/index.html
@@ -30,7 +30,7 @@
 	<link rel="stylesheet"
 		href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.3/css/fontawesome.min.css"
 		integrity="sha384-wESLQ85D6gbsF459vf1CiZ2+rr+CsxRY0RpiF1tLlQpDnAgg6rwdsUF1+Ics2bni" crossorigin="anonymous">
-	<script src="https://kit.fontawesome.com/54815f8287.js" crossorigin="anonymous"></script>
+	<script src="https://kit.fontawesome.com/2ab9935212.js" crossorigin="anonymous"></script>
 	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 	<script type="text/javascript" src="{% static 'js/splash.js'%}"></script>
 	<!-- Google Analytics script -->

--- a/timetable/templates/profile.html
+++ b/timetable/templates/profile.html
@@ -30,7 +30,7 @@
 	<link rel="stylesheet"
 		href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.3/css/fontawesome.min.css"
 		integrity="sha384-wESLQ85D6gbsF459vf1CiZ2+rr+CsxRY0RpiF1tLlQpDnAgg6rwdsUF1+Ics2bni" crossorigin="anonymous">
-	<script src="https://kit.fontawesome.com/54815f8287.js" crossorigin="anonymous"></script>
+	<script src="https://kit.fontawesome.com/2ab9935212.js" crossorigin="anonymous"></script>
 
 	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
 		integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">

--- a/timetable/templates/timetable.html
+++ b/timetable/templates/timetable.html
@@ -29,7 +29,7 @@
   <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" type="text/css" rel="stylesheet"
     integrity="sha256-7s5uDGW3AHqw6xtJmNNtr+OBRJUlgkNJEo78P4b0yRw= sha512-nNo+yCHEyn0smMxSswnf/OnX6/KwJuZTlNZBjauKhTK0c+zT+q5JOCx0UFhXQ6rJR9jg6Es8gPuD2uZcYDLqSw=="
     crossorigin="anonymous">
-    <script src="https://kit.fontawesome.com/a44255b29c.js" crossorigin="anonymous"></script>  <link rel="stylesheet" type="text/css"
+    <script src="https://kit.fontawesome.com/2ab9935212.js" crossorigin="anonymous"></script>  <link rel="stylesheet" type="text/css"
     href="https://cdnjs.cloudflare.com/ajax/libs/flat-ui/2.3.0/css/flat-ui.min.css">
   <link rel="stylesheet" type="text/css" href="{% static 'css/full-calendar.min.css'%}">
   <link rel="stylesheet" type="text/css" href="{% static 'css/ball-clip-rotate-multiple.css'%}">


### PR DESCRIPTION
The main error behind some icons not loading was that the token / embedded link for kitawesome had expired (I assume someone used their JHU email and it was erased with the account?) 

Also updated the about page to reflect our current team members, placing the others in the hall of fame
