### PR TITLE
Fix: Upgrade CI setup-node version

### DIFF
--- a/.github/workflows/semesterly.yml
+++ b/.github/workflows/semesterly.yml
@@ -54,7 +54,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/.github/workflows/tslint.yml
+++ b/.github/workflows/tslint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 14
           cache: "npm"


### PR DESCRIPTION
## Description
https://github.com/actions/setup-node/issues/1275 explains that setup-node@v2 is deprecated

