### PR TITLE
Change python and node versions in workflow

### DIFF
--- a/.github/workflows/semesterly.yml
+++ b/.github/workflows/semesterly.yml
@@ -30,8 +30,8 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8]
-        node-version: [14.x]
+        python-version: [3.11]
+        node-version: [18.x]
 
     steps:
       - name: Adjust hosts file


### PR DESCRIPTION
## Description
Update Github workflow:
- Python: 3.8 -> 3.11
- Node: 14.x -> 18.x

## Change Log
