### PR TITLE
Replacing `mock` with `unittest.mock`

### DIFF
--- a/build/semesterly-base/requirements_base.txt
+++ b/build/semesterly-base/requirements_base.txt
@@ -27,7 +27,6 @@ interruptingcow==0.7
 jsondiff==1.1.1
 jsonschema==3.2.0
 lxml==4.9.1
-mock==2.0.0
 nltk==3.6.6
 numpy==1.22.0
 oauth2client==4.1.2

--- a/helpers/test/test_runners.py
+++ b/helpers/test/test_runners.py
@@ -13,7 +13,7 @@
 from django.test import TransactionTestCase
 from django.test.runner import DiscoverRunner
 
-from mock import patch
+from unittest.mock import patch
 
 
 class NoDatabaseMixin:

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,6 @@ jsondiff==1.1.1
 jsonschema==3.2.0
 lxml==4.9.1
 markdown==3.4.1
-mock==2.0.0
 nltk==3.6.6
 numpy==1.22.0
 oauth2client==4.1.2


### PR DESCRIPTION
## Change Log
- Removes mock=2.0.0 imports and replaces with unittest.mock in a test util file

## Testing
`docker-compose up && docker-compose build` works and app runs locally