### PR TITLE
Upgrades Node base image to Node22

### DIFF
--- a/.github/workflows/semesterly.yml
+++ b/.github/workflows/semesterly.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.11]
-        node-version: [20.x]
+        node-version: [22.x]
 
     steps:
       - name: Adjust hosts file

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm
+FROM node:22-bookworm
 
 # Create code dir
 RUN mkdir /code


### PR DESCRIPTION
Uses node:22-bookworm instead of node:20-bookworm and also updates testing workflow to use node22.