### PR TITLE
Contact us through Google form instead of email

### DIFF
--- a/agreement/templates/privacypolicy.html
+++ b/agreement/templates/privacypolicy.html
@@ -669,8 +669,8 @@
               If you have any questions about this Privacy Policy or our
               information‑handling practices, or if you would like to request
               information about our disclosure of personal information to third parties,
-              please contact us by e‑mail at
-              <a href="mailto:semesterly@jhu.edu">semesterly@jhu.edu</a>.
+              please contact us through this 
+              <a href="https://forms.gle/4LgQAw7ySfEmnCX29">form</a>.
             </p>
           </div>
         </div>

--- a/static/js/redux/ui/Semesterly.tsx
+++ b/static/js/redux/ui/Semesterly.tsx
@@ -246,7 +246,7 @@ const Semesterly = () => {
                 <a href="/privacypolicy">Privacy</a>
               </li>
               <li className="footer-button" role="presentation">
-                <a href="mailto:semesterly@jhu.edu?Subject=Semesterly">Contact us</a>
+                <a href="https://forms.gle/4LgQAw7ySfEmnCX29">Contact us</a>
               </li>
               <li className="footer-button" role="presentation">
                 <a


### PR DESCRIPTION
## Change Log
Change Contact Us link in footer to Google form. 
Change "contact us through..." on privacy policy from email to Google form.