### PR TITLE
fixes bug in jhu course parser logic

### DIFF
--- a/parsing/schools/jhu/courses.py
+++ b/parsing/schools/jhu/courses.py
@@ -232,7 +232,9 @@ class Parser(BaseParser):
 
         # Get the last 10 years
         current_year = datetime.now().year
-        years = {str(year) for year in range(current_year - 10, current_year + 1)}
+        # include the next-from-current year as well. if those courses are not available, that semester will be filtered
+        #    out by years_and_terms_filter
+        years = {str(year) for year in range(current_year - 10, current_year + 2)}
 
         terms = {"Spring", "Fall", "Summer", "Intersession"}
 


### PR DESCRIPTION
includes the following year in the list of possible years.

example: `current_year ` is 2025. `years` should be `{2015, 2016, ..., 2025, 2026}`. 2026 would have previously not been included.