### PR TITLE
Fixes several bugs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
       - POSTGRES_PASSWORD=postgres
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   web:
     image: semesterly
@@ -23,7 +28,12 @@ services:
       - "8000:8000"
       - "3000:3000"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   localssl:
     image: jhuopensource/semesterly-caddy

--- a/semesterly/settings.py
+++ b/semesterly/settings.py
@@ -266,6 +266,7 @@ TEMPLATES = [
     }
 ]
 
+CSRF_TRUSTED_ORIGINS = ["https://jhu.sem.ly"]
 
 SESSION_COOKIE_SAMESITE = None
 

--- a/static/js/redux/actions/course_history_actions.jsx
+++ b/static/js/redux/actions/course_history_actions.jsx
@@ -47,7 +47,6 @@ export const postTranscript = (formData) => (dispatch) => {
     })
     .then((data) => data)
     .catch((error) => {
-      console.log(`error: ${error}`)
       dispatch(alertsActions.alertUploadFailed());
       throw error;
     });

--- a/static/js/redux/actions/course_history_actions.jsx
+++ b/static/js/redux/actions/course_history_actions.jsx
@@ -47,6 +47,7 @@ export const postTranscript = (formData) => (dispatch) => {
     })
     .then((data) => data)
     .catch((error) => {
+      console.log(`error: ${error}`)
       dispatch(alertsActions.alertUploadFailed());
       throw error;
     });

--- a/static/js/redux/ui/modals/UserSettingsModal.tsx
+++ b/static/js/redux/ui/modals/UserSettingsModal.tsx
@@ -58,10 +58,10 @@ const UserSettingsModal = () => {
   const showOverrided = useAppSelector((state) => state.userInfo.overrideShow);
   const hideOverrided = useAppSelector((state) => state.userInfo.overrideHide);
   const isUserInfoIncomplete = useAppSelector((state) =>
-    getIsUserInfoIncomplete(state),
+    getIsUserInfoIncomplete(state)
   );
   const isSigningUp = useAppSelector(
-    (state) => !state.userInfo.overrideShow && getIsUserInfoIncomplete(state),
+    (state) => !state.userInfo.overrideShow && getIsUserInfoIncomplete(state)
   );
   const isDeleted = useAppSelector((state) => state.userInfo.isDeleted);
 

--- a/static/js/redux/ui/modals/UserSettingsModal.tsx
+++ b/static/js/redux/ui/modals/UserSettingsModal.tsx
@@ -22,6 +22,7 @@ import { isIncomplete as TOSIncomplete } from "../../util";
 import { isUserInfoIncomplete as areUserSettingsIncomplete } from "../../state/slices";
 import { getIsUserInfoIncomplete } from "../../state";
 import { selectTheme } from "../../state/slices/themeSlice";
+import Cookie from "js-cookie";
 
 interface Option {
   value: string;
@@ -157,10 +158,11 @@ const UserSettingsModal = () => {
 
   useEffect(() => {
     if (isDeleted) {
-      const link = document.createElement("a");
-      link.href = "/user/logout/";
-      document.body.appendChild(link);
-      link.click();
+      fetch("/user/logout/", {
+        method: "POST",
+        credentials: "include",
+        headers: { "X-CSRFToken": Cookie.get("csrftoken") },
+      }).then(() => (window.location.href = "/"));
     }
   }, [isDeleted]);
 

--- a/static/js/redux/ui/modals/UserSettingsModal.tsx
+++ b/static/js/redux/ui/modals/UserSettingsModal.tsx
@@ -162,7 +162,9 @@ const UserSettingsModal = () => {
         method: "POST",
         credentials: "include",
         headers: { "X-CSRFToken": Cookie.get("csrftoken") },
-      }).then(() => (window.location.href = "/"));
+      }).then(() => {
+        window.location.href = "/";
+      });
     }
   }, [isDeleted]);
 

--- a/student/urls.py
+++ b/student/urls.py
@@ -11,14 +11,13 @@
 # GNU General Public License for more details.
 
 from django.urls import re_path
-from django.contrib.auth.views import LogoutView
 
 from helpers.mixins import FeatureFlowView
 import student.views
 
 urlpatterns = [
     # profile management
-    re_path(r"^user/logout/$", LogoutView.as_view(next_page="/")),
+    re_path(r"^user/logout/$", student.views.logout_view),
     re_path(r"^user/settings/$", student.views.UserView.as_view()),
     re_path(
         r"^delete_account/$",

--- a/student/views.py
+++ b/student/views.py
@@ -86,9 +86,11 @@ def accept_tos(request):
     student.save()
     return HttpResponse(status=204)
 
+
 def logout_view(request):
     logout(request)
     return redirect("/")
+
 
 class UserView(RedirectToSignupMixin, APIView):
     """Handles the accessing and mutating of user information and preferences."""

--- a/student/views.py
+++ b/student/views.py
@@ -16,8 +16,9 @@ from django.urls import reverse
 from django.db.models import Q, Count
 from django.forms.models import model_to_dict
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, render, redirect
 from django.views.decorators.csrf import csrf_exempt
+from django.contrib.auth import logout
 from django.utils import timezone
 from hashids import Hashids
 from rest_framework.generics import GenericAPIView
@@ -85,6 +86,9 @@ def accept_tos(request):
     student.save()
     return HttpResponse(status=204)
 
+def logout_view(request):
+    logout(request)
+    return redirect("/")
 
 class UserView(RedirectToSignupMixin, APIView):
     """Handles the accessing and mutating of user information and preferences."""


### PR DESCRIPTION
## 📝 Summary
Django upgrade to v4+ causes some CSRF-related issues resulting in calls to backend getting access denied. Updated certian settings files appropriately. Also restores old docker-compose.yml, fixes linter error, and fixes logout issue due to depreciated Django view.

## 🔍 Change Log
- `semesterly/settings.py`: added `CSRF_TRUSTED_ORIGINS`
- `static/js/redux/ui/modals/UserSettingsModal.tsx`: updates from link-click to a POST request. a clicked link results in a GET request to the LogoutView, which is depreciated in Django v5+
- `student/views.py`: makes custom logout view in accordance with LogoutView depreciation. see [docs](https://docs.djangoproject.com/en/5.2/topics/auth/default/) for updated instructions
- `student/urls.py`: updates url with new logout view
- `docker-compose.yml`: restores certain parts of this file to match previous docker-compose in `develop`
- `static/js/redux/ui/modals/UserSettingsModal.tsx`: runs prettier

## ⚠️ Base Testing
Please fill in the following required testing steps with a checkbox (✅) before making this PR, or indicate why they are not necessary for this change:

[✅] `docker-compose build && docker-compose up` and the `https://jhu.sem.ly` endpoint works successfully

[✅]  Semesterly CI successful

[✅]  Backend linter successful

[✅]  TSLint successful

## 💻 Local Testing Instructions
- Verify that logging out does not result in a 403 error
- Successfully upload transcript to course history feature without getting "file not uploaded" error

<h4>To test locally from a forked repo, run:</h4>

```bash
git fetch https://github.com/<username>/<fork-repo>.git <branch-name>:pr-<PR_NUMBER> && git checkout pr-<PR_NUMBER>
```
<em>Please contact the owner of the fork in case the fork's branches are not publically accessible.</em>