### PR TITLE
Social sync: add ghost overlay sharing with realtime updates

### DIFF
--- a/analytics/migrations/0023_sharedtimetable_social_sync_fields.py
+++ b/analytics/migrations/0023_sharedtimetable_social_sync_fields.py
@@ -1,0 +1,56 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("student", "0046_delete_registrationtoken"),
+        ("analytics", "0022_uierrorlog_squashed_0024_alter_uierrorlog_options"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="sharedtimetable",
+            name="updated_at",
+            field=models.DateTimeField(auto_now=True, null=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="sharedtimetable",
+            name="source_timetable",
+            field=models.ForeignKey(
+                blank=True,
+                default=None,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="shared_timetables",
+                to="student.personaltimetable",
+            ),
+        ),
+        migrations.AddField(
+            model_name="sharedtimetable",
+            name="share_token",
+            field=models.CharField(
+                blank=True, db_index=True, max_length=64, null=True, unique=True
+            ),
+        ),
+        migrations.AddField(
+            model_name="sharedtimetable",
+            name="permission",
+            field=models.CharField(
+                choices=[("view", "View"), ("edit", "Edit")],
+                default="view",
+                max_length=10,
+            ),
+        ),
+        migrations.AddField(
+            model_name="sharedtimetable",
+            name="expires_at",
+            field=models.DateTimeField(blank=True, default=None, null=True),
+        ),
+        migrations.AddField(
+            model_name="sharedtimetable",
+            name="revoked_at",
+            field=models.DateTimeField(blank=True, default=None, null=True),
+        ),
+    ]

--- a/analytics/models.py
+++ b/analytics/models.py
@@ -12,7 +12,7 @@
 
 import secrets
 
-from django.db import models
+from django.db import IntegrityError, models
 
 from timetable.models import *
 from student.models import Student, PersonalTimetable
@@ -55,12 +55,15 @@ class SharedTimetable(Timetable):
     def ensure_share_token(self):
         if self.share_token:
             return self.share_token
-        token = secrets.token_urlsafe(24)
-        while SharedTimetable.objects.filter(share_token=token).exists():
+        while True:
             token = secrets.token_urlsafe(24)
-        self.share_token = token
-        self.save(update_fields=["share_token"])
-        return token
+            self.share_token = token
+            try:
+                self.save(update_fields=["share_token"])
+                return token
+            except IntegrityError:
+                # Extremely unlikely token collision; retry with a fresh token.
+                self.share_token = None
 
 
 class SharedTimetableView(models.Model):

--- a/analytics/models.py
+++ b/analytics/models.py
@@ -10,8 +10,12 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
+import secrets
+
+from django.db import models
+
 from timetable.models import *
-from student.models import Student
+from student.models import Student, PersonalTimetable
 from django.contrib.auth.models import User
 
 
@@ -25,9 +29,38 @@ class SharedTimetable(Timetable):
 
     has_conflict = models.BooleanField(blank=True, default=False)
     time_created = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
     student = models.ForeignKey(
         Student, null=True, default=None, on_delete=models.deletion.CASCADE
     )
+    source_timetable = models.ForeignKey(
+        PersonalTimetable,
+        null=True,
+        blank=True,
+        default=None,
+        on_delete=models.deletion.SET_NULL,
+        related_name="shared_timetables",
+    )
+    share_token = models.CharField(
+        max_length=64, null=True, blank=True, unique=True, db_index=True
+    )
+    permission = models.CharField(
+        max_length=10,
+        default="view",
+        choices=(("view", "View"), ("edit", "Edit")),
+    )
+    expires_at = models.DateTimeField(null=True, blank=True, default=None)
+    revoked_at = models.DateTimeField(null=True, blank=True, default=None)
+
+    def ensure_share_token(self):
+        if self.share_token:
+            return self.share_token
+        token = secrets.token_urlsafe(24)
+        while SharedTimetable.objects.filter(share_token=token).exists():
+            token = secrets.token_urlsafe(24)
+        self.share_token = token
+        self.save(update_fields=["share_token"])
+        return token
 
 
 class SharedTimetableView(models.Model):

--- a/build/caddy/Caddyfile
+++ b/build/caddy/Caddyfile
@@ -1,6 +1,9 @@
 #This is a local self-signed SSL proxy for development
 *.sem.ly:443 {
     tls self_signed
+    proxy /ws web:8000 {
+        websocket
+    }
     proxy / web:8000 {
         transparent
     }
@@ -15,6 +18,9 @@
 }
 sem.ly:443 {
     tls self_signed
+    proxy /ws web:8000 {
+        websocket
+    }
     proxy / web:8000 {
         transparent
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,14 +13,25 @@ services:
       timeout: 5s
       retries: 5
 
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
   web:
     image: semesterly
     container_name: semesterly-web
     environment:
       - NODE_ENV=development
       - PYTHONUNBUFFERED=1
+      - REDIS_URL=redis://redis:6379/0
     build: .
-    command: bash -c "python3 manage.py migrate; yarn watch & python3 /code/manage.py runserver 0.0.0.0:8000"
+    command: bash -c "python3 manage.py migrate; yarn watch & python3 -m uvicorn semesterly.asgi:application --host 0.0.0.0 --port 8000"
     volumes:
       - .:/code
       - /code/node_modules
@@ -29,6 +40,8 @@ services:
       - "3000:3000"
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     logging:
       options:

--- a/helpers/mixins.py
+++ b/helpers/mixins.py
@@ -28,6 +28,7 @@ from timetable.models import Semester
 from timetable.school_mappers import SCHOOLS_MAP
 from parsing.schools.active import ACTIVE_SCHOOLS
 from timetable.utils import get_current_semesters
+from semesterly.settings import ENABLE_SOCIAL_SYNC_GHOST
 
 
 class ValidateSubdomainMixin:
@@ -106,6 +107,7 @@ class FeatureFlowView(ValidateSubdomainMixin, APIView):
             "examSupportedSemesters": list(map(all_semesters.index, final_exams)),
             "timeUpdatedTos": Agreement.objects.latest().last_updated.isoformat(),
             "featureFlow": dict(feature_flow, name=self.feature_name),
+            "enableSocialSyncGhost": ENABLE_SOCIAL_SYNC_GHOST,
         }
 
         return render(request, "timetable.html", {"init_data": json.dumps(init_data)})

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ django-picklefield==3.3
 django-webpack-loader==0.7.0
 djangorestframework==3.16.1
 drf-yasg==1.21.11
+channels==4.2.2
+channels-redis==4.2.1
 fake-useragent==2.2.0
 future==1.0.0
 rapidfuzz==3.14.1

--- a/semesterly/asgi.py
+++ b/semesterly/asgi.py
@@ -1,0 +1,22 @@
+"""
+ASGI config for semesterly project.
+"""
+
+import os
+
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
+from django.contrib.staticfiles.handlers import ASGIStaticFilesHandler
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "semesterly.settings")
+
+django_asgi_app = get_asgi_application()
+from .routing import websocket_urlpatterns
+
+application = ProtocolTypeRouter(
+    {
+        "http": ASGIStaticFilesHandler(django_asgi_app),
+        "websocket": AuthMiddlewareStack(URLRouter(websocket_urlpatterns)),
+    }
+)

--- a/semesterly/routing.py
+++ b/semesterly/routing.py
@@ -1,0 +1,10 @@
+from django.urls import re_path
+
+from timetable.consumers import SharedTimetableConsumer
+
+websocket_urlpatterns = [
+    re_path(
+        r"^ws/timetables/links/(?P<slug>[^/]+)/$",
+        SharedTimetableConsumer.as_asgi(),
+    ),
+]

--- a/semesterly/settings.py
+++ b/semesterly/settings.py
@@ -29,6 +29,9 @@ import logging, logging.config
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 PROJECT_DIRECTORY = os.getcwd()
 PARSING_MODULE = "parsing"
+ENABLE_SOCIAL_SYNC_GHOST = (
+    os.environ.get("ENABLE_SOCIAL_SYNC_GHOST", "true").strip().lower() == "true"
+)
 
 
 def get_secret(key):
@@ -205,6 +208,7 @@ INSTALLED_APPS = (
     "drf_yasg",
     "rest_framework",
     "social_django",
+    "channels",
     "webpack_loader",
     "agreement",
     "analytics",
@@ -273,6 +277,7 @@ SESSION_COOKIE_SAMESITE = None
 ROOT_URLCONF = "semesterly.urls"
 
 WSGI_APPLICATION = "semesterly.wsgi.application"
+ASGI_APPLICATION = "semesterly.asgi.application"
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
@@ -376,6 +381,19 @@ CACHES = {
     }
 }
 CACHALOT_ENABLED = True
+
+REDIS_URL = os.environ.get("REDIS_URL")
+if REDIS_URL:
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "CONFIG": {"hosts": [REDIS_URL]},
+        }
+    }
+else:
+    CHANNEL_LAYERS = {
+        "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}
+    }
 
 try:
     from .local_settings import *

--- a/static/js/redux/__tests__/ghost_timetable_slice.test.ts
+++ b/static/js/redux/__tests__/ghost_timetable_slice.test.ts
@@ -1,0 +1,40 @@
+import ghostTimetableReducer, {
+  ghostTimetableActions,
+} from "../state/slices/ghostTimetableSlice";
+
+describe("ghostTimetableSlice", () => {
+  it("loads and clears ghost overlay state", () => {
+    let state = ghostTimetableReducer(undefined, { type: "unknown" });
+    state = ghostTimetableReducer(
+      state,
+      ghostTimetableActions.startGhostLoad("abc123")
+    );
+    expect(state.enabled).toBe(true);
+    expect(state.shareSlug).toBe("abc123");
+    expect(state.isLoading).toBe(true);
+
+    state = ghostTimetableReducer(
+      state,
+      ghostTimetableActions.receiveGhostTimetable({
+        slug: "abc123",
+        permission: "view",
+        updatedAt: "2026-01-01T00:00:00Z",
+        timetable: {
+          id: null,
+          slots: [],
+          has_conflict: false,
+          show_weekend: false,
+          name: "Shared",
+          avg_rating: 0,
+          events: [],
+        },
+      })
+    );
+    expect(state.isLoading).toBe(false);
+    expect(state.timetable?.name).toBe("Shared");
+
+    state = ghostTimetableReducer(state, ghostTimetableActions.clearGhostOverlay());
+    expect(state.enabled).toBe(false);
+    expect(state.timetable).toBeNull();
+  });
+});

--- a/static/js/redux/actions/calendar_actions.jsx
+++ b/static/js/redux/actions/calendar_actions.jsx
@@ -18,6 +18,8 @@ import FileSaver from "browser-filesaver";
 import {
   // getAddTTtoGCalEndpoint,
   getLogiCalEndpoint,
+  getGhostTimetableEndpoint,
+  getGhostTimetableWebsocketEndpoint,
   getRequestShareTimetableLinkEndpoint,
   getCourseShareLink,
 } from "../constants/endpoints";
@@ -28,7 +30,11 @@ import {
   getActiveTimetable,
 } from "../state";
 import { calendarActions } from "../state/slices";
+import { ghostTimetableActions } from "../state/slices/ghostTimetableSlice";
 import { saveCalendarModalActions } from "../state/slices/saveCalendarModalSlice";
+import { receiveCourses } from "./initActions";
+
+let ghostTimetableSocket = null;
 
 const DAY_MAP = {
   M: "mo",
@@ -78,6 +84,100 @@ export const fetchShareTimetableLink = () => (dispatch, getState) => {
     .then((ref) => {
       dispatch(receiveShareLink(`/timetables/links/${ref.slug}`));
     });
+};
+
+export const fetchGhostTimetableBySlug = (slug) => (dispatch) => {
+  dispatch(ghostTimetableActions.startGhostLoad(slug));
+  return fetch(getGhostTimetableEndpoint(slug), {
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    method: "GET",
+    credentials: "include",
+  })
+    .then((response) => {
+      if (response.status !== 200) {
+        throw new Error("Unable to load ghost timetable");
+      }
+      return response.json();
+    })
+    .then((payload) => {
+      dispatch(receiveCourses(payload.courses));
+      dispatch(
+        ghostTimetableActions.receiveGhostTimetable({
+          slug: payload.slug,
+          timetable: payload.sharedTimetable,
+          permission: payload.permission || "view",
+          updatedAt: payload.updatedAt || null,
+        })
+      );
+      return payload;
+    })
+    .catch(() => {
+      dispatch(
+        ghostTimetableActions.setGhostError(
+          "Could not load shared timetable overlay."
+        )
+      );
+      return null;
+    });
+};
+
+export const disconnectGhostTimetableSocket = () => (dispatch) => {
+  if (ghostTimetableSocket !== null) {
+    ghostTimetableSocket.close();
+    ghostTimetableSocket = null;
+  }
+  dispatch(ghostTimetableActions.setGhostWebsocketConnected(false));
+};
+
+export const connectGhostTimetableSocket = (slug) => (dispatch) => {
+  dispatch(disconnectGhostTimetableSocket());
+  try {
+    ghostTimetableSocket = new WebSocket(getGhostTimetableWebsocketEndpoint(slug));
+  } catch (error) {
+    dispatch(
+      ghostTimetableActions.setGhostError(
+        "Could not connect to live ghost updates."
+      )
+    );
+    return;
+  }
+
+  ghostTimetableSocket.onopen = () => {
+    dispatch(ghostTimetableActions.setGhostWebsocketConnected(true));
+  };
+  ghostTimetableSocket.onclose = () => {
+    dispatch(ghostTimetableActions.setGhostWebsocketConnected(false));
+  };
+  ghostTimetableSocket.onerror = () => {
+    dispatch(
+      ghostTimetableActions.setGhostError("Live updates disconnected unexpectedly.")
+    );
+  };
+  ghostTimetableSocket.onmessage = (event) => {
+    try {
+      const payload = JSON.parse(event.data);
+      if (payload.type === "timetable.updated") {
+        dispatch(fetchGhostTimetableBySlug(slug));
+      }
+    } catch (error) {
+      // Ignore malformed events and keep stream alive.
+    }
+  };
+};
+
+export const startGhostOverlay = (slug) => (dispatch) =>
+  dispatch(fetchGhostTimetableBySlug(slug)).then((payload) => {
+    if (payload) {
+      dispatch(connectGhostTimetableSocket(payload.slug));
+    }
+  });
+
+export const stopGhostOverlay = () => (dispatch) => {
+  dispatch(disconnectGhostTimetableSocket());
+  dispatch(ghostTimetableActions.clearGhostOverlay());
 };
 
 export const fetchSISTimetableData = () => (dispatch, getState) => {

--- a/static/js/redux/actions/calendar_actions.jsx
+++ b/static/js/redux/actions/calendar_actions.jsx
@@ -102,18 +102,7 @@ export const fetchGhostTimetableBySlug = (slug) => (dispatch) => {
       }
       return response.json();
     })
-    .then((payload) => {
-      dispatch(receiveCourses(payload.courses));
-      dispatch(
-        ghostTimetableActions.receiveGhostTimetable({
-          slug: payload.slug,
-          timetable: payload.sharedTimetable,
-          permission: payload.permission || "view",
-          updatedAt: payload.updatedAt || null,
-        })
-      );
-      return payload;
-    })
+    .then((payload) => applyGhostTimetablePayload(dispatch, payload))
     .catch(() => {
       dispatch(
         ghostTimetableActions.setGhostError(
@@ -160,12 +149,30 @@ export const connectGhostTimetableSocket = (slug) => (dispatch) => {
     try {
       const payload = JSON.parse(event.data);
       if (payload.type === "timetable.updated") {
+        if (payload.sharedTimetable && payload.courses) {
+          applyGhostTimetablePayload(dispatch, payload);
+          return;
+        }
+        // Backward-compatible fallback while websocket payload rolls out.
         dispatch(fetchGhostTimetableBySlug(slug));
       }
     } catch (error) {
       // Ignore malformed events and keep stream alive.
     }
   };
+};
+
+const applyGhostTimetablePayload = (dispatch, payload) => {
+  dispatch(receiveCourses(payload.courses));
+  dispatch(
+    ghostTimetableActions.receiveGhostTimetable({
+      slug: payload.slug,
+      timetable: payload.sharedTimetable,
+      permission: payload.permission || "view",
+      updatedAt: payload.updatedAt || null,
+    })
+  );
+  return payload;
 };
 
 export const startGhostOverlay = (slug) => (dispatch) =>

--- a/static/js/redux/constants/endpoints.ts
+++ b/static/js/redux/constants/endpoints.ts
@@ -77,6 +77,12 @@ export const getRejectFriendRequestEndpoint = (
 export const getSchoolInfoEndpoint = (school: string) => `/school/${school}/`;
 export const getReactToCourseEndpoint = () => "/user/reactions/";
 export const getRequestShareTimetableLinkEndpoint = () => "/timetables/links/";
+export const getGhostTimetableEndpoint = (slug: string) =>
+  `/timetables/links/${slug}/ghost/`;
+export const getGhostTimetableWebsocketEndpoint = (slug: string) => {
+  const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+  return `${protocol}://${window.location.host}/ws/timetables/links/${slug}/`;
+};
 export const acceptTOSEndpoint = () => "/tos/accept/";
 export function getCourseShareLinkFromModal(code: Course["code"], semester: Semester) {
   return `/course/${encodeURIComponent(code)}/${semester.name}/${semester.year}`;

--- a/static/js/redux/state/index.tsx
+++ b/static/js/redux/state/index.tsx
@@ -44,6 +44,7 @@ import registrar from "./slices/registrarSlice";
 import entities, * as fromEntities from "./slices/entitiesSlice";
 import dragSearch from "./slices/dragSearchSlice";
 import theme from "./slices/themeSlice";
+import ghostTimetable from "./slices/ghostTimetableSlice";
 import { Slot, Timetable } from "../constants/commonTypes";
 
 export const reducers = {
@@ -75,6 +76,7 @@ export const reducers = {
   userInfo,
   compareTimetable,
   dragSearch,
+  ghostTimetable,
 };
 
 const store = configureStore({ reducer: reducers });

--- a/static/js/redux/state/slices/ghostTimetableSlice.ts
+++ b/static/js/redux/state/slices/ghostTimetableSlice.ts
@@ -1,0 +1,68 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+import { RootState } from "../index";
+import { Timetable } from "../../constants/commonTypes";
+
+interface GhostTimetableSliceState {
+  enabled: boolean;
+  shareSlug: string | null;
+  timetable: Timetable | null;
+  permission: "view" | "edit";
+  isLoading: boolean;
+  websocketConnected: boolean;
+  lastSyncedAt: string | null;
+  error: string | null;
+}
+
+const initialState: GhostTimetableSliceState = {
+  enabled: false,
+  shareSlug: null,
+  timetable: null,
+  permission: "view",
+  isLoading: false,
+  websocketConnected: false,
+  lastSyncedAt: null,
+  error: null,
+};
+
+const ghostTimetableSlice = createSlice({
+  name: "ghostTimetable",
+  initialState,
+  reducers: {
+    startGhostLoad: (state, action: PayloadAction<string>) => {
+      state.enabled = true;
+      state.shareSlug = action.payload;
+      state.isLoading = true;
+      state.error = null;
+    },
+    receiveGhostTimetable: (
+      state,
+      action: PayloadAction<{
+        slug: string;
+        timetable: Timetable;
+        permission: "view" | "edit";
+        updatedAt: string | null;
+      }>
+    ) => {
+      state.enabled = true;
+      state.shareSlug = action.payload.slug;
+      state.timetable = action.payload.timetable;
+      state.permission = action.payload.permission;
+      state.lastSyncedAt = action.payload.updatedAt;
+      state.isLoading = false;
+      state.error = null;
+    },
+    setGhostWebsocketConnected: (state, action: PayloadAction<boolean>) => {
+      state.websocketConnected = action.payload;
+    },
+    setGhostError: (state, action: PayloadAction<string>) => {
+      state.error = action.payload;
+      state.isLoading = false;
+    },
+    clearGhostOverlay: () => initialState,
+  },
+});
+
+export const selectGhostTimetable = (state: RootState) => state.ghostTimetable;
+export const ghostTimetableActions = ghostTimetableSlice.actions;
+export default ghostTimetableSlice.reducer;

--- a/static/js/redux/state/slices/index.ts
+++ b/static/js/redux/state/slices/index.ts
@@ -2,5 +2,6 @@ export * from "./userAcquisitionModalSlice";
 export * from "./userInfoSlice";
 export * from "./alertsSlice";
 export * from "./calendarSlice";
+export * from "./ghostTimetableSlice";
 export * from "./courseInfoSlice";
 export * from "./advancedSearchSlice";

--- a/static/js/redux/state/slices/uiSlice.ts
+++ b/static/js/redux/state/slices/uiSlice.ts
@@ -13,12 +13,14 @@ interface UiSliceState {
   searchHover: number;
   courseToColourIndex: any; // { courseId: index }
   uses12HrTime: boolean;
+  enableSocialSyncGhost: boolean;
 }
 
 const initialState: UiSliceState = {
   searchHover: 0,
   courseToColourIndex: {},
   uses12HrTime: false,
+  enableSocialSyncGhost: false,
 };
 
 const uiSlice = createSlice({
@@ -33,6 +35,7 @@ const uiSlice = createSlice({
     builder
       .addCase(initAllState, (state, action: PayloadAction<any>) => {
         state.uses12HrTime = action.payload.uses12HrTime;
+        state.enableSocialSyncGhost = !!action.payload.enableSocialSyncGhost;
       })
       .addCase(receiveTimetables, (state, action: PayloadAction<Timetable[]>) => {
         const courses =

--- a/static/js/redux/ui/Calendar.tsx
+++ b/static/js/redux/ui/Calendar.tsx
@@ -33,6 +33,10 @@ import { getMaxTimetableHeightBasedOnWindowHeight } from "../util";
 import useWindowSize from "../hooks/useWindowSize";
 import { getFirstTTStartHour } from "../state";
 import html2canvas from "html2canvas";
+import {
+  startGhostOverlay,
+  stopGhostOverlay,
+} from "../actions/calendar_actions";
 
 interface RowProps {
   isLoggedIn: boolean;
@@ -344,6 +348,68 @@ const Calendar = (props: CalendarProps) => {
   const isComparingTimetables = useAppSelector(
     (state) => state.compareTimetable.isComparing
   );
+  const enableSocialSyncGhost = useAppSelector(
+    (state) => state.ui.enableSocialSyncGhost
+  );
+  const ghostOverlay = useAppSelector((state) => state.ghostTimetable);
+  const parseGhostSlug = (input: string) => {
+    const trimmed = input.trim();
+    if (!trimmed) {
+      return null;
+    }
+    if (!trimmed.includes("/")) {
+      return trimmed;
+    }
+    const match = trimmed.match(/\/timetables\/links\/([^/]+)/);
+    return match ? match[1] : null;
+  };
+  const toggleGhostOverlay = () => {
+    if (ghostOverlay.enabled) {
+      dispatch(stopGhostOverlay());
+      return;
+    }
+    const raw = window.prompt(
+      "Paste a shared timetable link or slug to overlay as ghost."
+    );
+    if (!raw) {
+      return;
+    }
+    const slug = parseGhostSlug(raw);
+    if (!slug) {
+      return;
+    }
+    dispatch(startGhostOverlay(slug));
+  };
+  useEffect(() => {
+    return () => {
+      dispatch(stopGhostOverlay());
+    };
+  }, [dispatch]);
+
+  const ghostOverlayButton = (
+    <div className="cal-btn-wrapper">
+      <Tooltip
+        title={
+          <Typography fontSize={12}>
+            {ghostOverlay.enabled ? "Disable Ghost Overlay" : "Enable Ghost Overlay"}
+          </Typography>
+        }
+      >
+        <button
+          onClick={toggleGhostOverlay}
+          className="save-timetable add-button"
+          data-tip
+        >
+          <i
+            className={classnames("fa", {
+              "fa-user-plus": !ghostOverlay.enabled,
+              "fa-user-times": ghostOverlay.enabled,
+            })}
+          />
+        </button>
+      </Tooltip>
+    </div>
+  );
   const toolbar = isComparingTimetables ? (
     <>
       <ShowWeekendsSwitch isMobile={false} />
@@ -353,6 +419,7 @@ const Calendar = (props: CalendarProps) => {
       {addSISButton}
       {screenShotButton}
       {toggleCustomEventModeButton}
+      {enableSocialSyncGhost && ghostOverlayButton}
       {shareButton}
       {shareLink}
       {saveToCalendarButton}

--- a/static/js/redux/ui/Calendar.tsx
+++ b/static/js/redux/ui/Calendar.tsx
@@ -369,7 +369,7 @@ const Calendar = (props: CalendarProps) => {
       return;
     }
     const raw = window.prompt(
-      "Paste a shared timetable link or slug to overlay as ghost."
+      "Paste a shared timetable link or code.\n\nExample link: jhu.sem.ly/timetables/links/abc123\nExample code: abc123"
     );
     if (!raw) {
       return;

--- a/static/js/redux/ui/GhostSlot.tsx
+++ b/static/js/redux/ui/GhostSlot.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+
+import { HALF_HOUR_HEIGHT } from "../constants/constants";
+
+type GhostSlotProps = {
+  id: string;
+  color: string;
+  borderColor: string;
+  text: string;
+  section: string;
+  location: string;
+  time_start: string;
+  time_end: string;
+  num_conflicts: number;
+  shift_index: number;
+  depth_level: number;
+  uses12HrTime: boolean;
+};
+
+const GhostSlot = (props: GhostSlotProps) => {
+  const formatDisplayTime = (time: string) => {
+    if (!props.uses12HrTime) {
+      return time;
+    }
+    const [hourRaw, minute] = time.split(":");
+    const hour = parseInt(hourRaw, 10);
+    if (hour > 12) {
+      return `${hour - 12}:${minute}`;
+    }
+    return time;
+  };
+  const startHour = parseInt(props.time_start.split(":")[0], 10);
+  const startMinute = parseInt(props.time_start.split(":")[1], 10);
+  const endHour = parseInt(props.time_end.split(":")[0], 10);
+  const endMinute = parseInt(props.time_end.split(":")[1], 10);
+
+  const top =
+    startHour * (HALF_HOUR_HEIGHT * 2 + 2) + startMinute * (HALF_HOUR_HEIGHT / 30);
+  const bottom =
+    endHour * (HALF_HOUR_HEIGHT * 2 + 2) + endMinute * (HALF_HOUR_HEIGHT / 30) - 1;
+  const totalSlotWidth = 100 - 7 * props.depth_level;
+  const slotWidthPercentage = totalSlotWidth / props.num_conflicts;
+  const pushLeft = props.shift_index * slotWidthPercentage + 7 * props.depth_level;
+
+  return (
+    <div className="fc-event-container" style={{ pointerEvents: "none" }}>
+      <div
+        className="fc-time-grid-event fc-event slot ghost-slot"
+        id={props.id}
+        style={{
+          top,
+          bottom: -bottom,
+          right: "0%",
+          width: `${slotWidthPercentage}%`,
+          left: `${pushLeft}%`,
+          zIndex: 1,
+          opacity: 0.45,
+          backgroundColor: props.color,
+          border: `1px dashed ${props.borderColor}`,
+          color: "#111827",
+          boxShadow: "none",
+        }}
+      >
+        <div className="fc-content">
+          <div className="fc-time">
+            <span className="fc-time-name">{props.text}</span>
+          </div>
+          <div className="fc-time">
+            <span>
+              {props.section}
+              {props.section ? " " : ""}
+              {formatDisplayTime(props.time_start)} - {formatDisplayTime(props.time_end)}
+            </span>
+          </div>
+          <div className="fc-time">
+            <span>{props.location}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GhostSlot;

--- a/static/js/redux/ui/SlotManager.tsx
+++ b/static/js/redux/ui/SlotManager.tsx
@@ -45,6 +45,7 @@ import { uniqBy } from "lodash";
 import { selectGradient } from "../state/slices/compareTimetableSlice";
 import { selectSlotColorData, selectTheme } from "../state/slices/themeSlice";
 import SearchSlot from "./SearchSlot";
+import GhostSlot from "./GhostSlot";
 
 function getConflictStyles(slotsByDay: any) {
   const styledSlotsByDay = slotsByDay;
@@ -172,6 +173,11 @@ const SlotManager = (props: { days: string[] }) => {
   );
   const slots = isComparingTimetables ? comparedSlots : timetableSlots;
   const gradient = useAppSelector(selectGradient);
+  const ghostOverlayEnabled = useAppSelector((state) => state.ghostTimetable.enabled);
+  const ghostTimetable = useAppSelector((state) => state.ghostTimetable.timetable);
+  const ghostSlots = useAppSelector((state) =>
+    ghostOverlayEnabled && ghostTimetable ? getDenormTimetable(state, ghostTimetable).slots : []
+  );
   const courseToColourIndex = useAppSelector((state) => state.ui.courseToColourIndex);
   const customEvents = useAppSelector((state) => state.customEvents.events);
   const searchSlot = useAppSelector((state) => state.dragSearch.slot);
@@ -276,7 +282,48 @@ const SlotManager = (props: { days: string[] }) => {
     return getConflictStyles(slotsByDay);
   };
 
+  const getGhostSlotsByDay = () => {
+    const ghostSlotsByDay: any = {
+      M: [],
+      T: [],
+      W: [],
+      R: [],
+      F: [],
+      S: [],
+      U: [],
+    };
+    const ghostColorData = [
+      {
+        background: "#9fc4ff",
+        highlight: "#9fc4ff",
+        border: "#3f62a6",
+        font: "#1d2433",
+      },
+    ];
+    if (!ghostOverlayEnabled) {
+      return ghostSlotsByDay;
+    }
+    ghostSlots.forEach((slot) => {
+      const { course, section, offerings } = slot;
+      offerings
+        .filter((offering) => offering.day in ghostSlotsByDay)
+        .forEach((offering) => {
+          const displaySlot = slotToDisplayOffering(
+            course,
+            section,
+            offering,
+            0,
+            ghostColorData
+          );
+          displaySlot.ghostText = course.name;
+          ghostSlotsByDay[offering.day].push(displaySlot);
+        });
+    });
+    return getConflictStyles(ghostSlotsByDay);
+  };
+
   const slotsByDay = getSlotsByDay();
+  const ghostSlotsByDay = getGhostSlotsByDay();
 
   const courseSections = useAppSelector((state) => state.courseSections);
   const isLocked = (courseId: number, section: number) => {
@@ -315,6 +362,23 @@ const SlotManager = (props: { days: string[] }) => {
 
   const dispatch = useAppDispatch();
   const allSlots = props.days.map((day, i) => {
+    const ghostDaySlots = ghostSlotsByDay[day].map((slot: any, j: number) => (
+      <GhostSlot
+        id={`ghost-${slot.id}-${i}-${j}`}
+        key={`ghost-${slot.id}-${i}-${j}`}
+        color={slot.colorData[slot.colourId]?.background || "#9fc4ff"}
+        borderColor={slot.colorData[slot.colourId]?.border || "#3f62a6"}
+        text={slot.ghostText || slot.name || "Shared course"}
+        section={slot.meeting_section || ""}
+        location={slot.location || ""}
+        time_start={slot.time_start}
+        time_end={slot.time_end}
+        num_conflicts={slot.num_conflicts || 1}
+        shift_index={slot.shift_index || 0}
+        depth_level={slot.depth_level || 0}
+        uses12HrTime={uses12HrTime}
+      />
+    ));
     const daySlots = slotsByDay[day].map((slot: any, j: number) => {
       const courseId = slot.courseId;
       const locked = isLocked(courseId, slot.meeting_section);
@@ -359,7 +423,10 @@ const SlotManager = (props: { days: string[] }) => {
     });
     return (
       <td key={day}>
-        <div className="fc-content-col">{daySlots}</div>
+        <div className="fc-content-col">
+          {ghostDaySlots}
+          {daySlots}
+        </div>
       </td>
     );
   });

--- a/student/views.py
+++ b/student/views.py
@@ -13,6 +13,7 @@
 import json
 
 from django.urls import reverse
+from django.db import transaction
 from django.db.models import Q, Count
 from django.forms.models import model_to_dict
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
@@ -50,6 +51,7 @@ from timetable.serializers import (
     EventSerializer,
     PersonalTimeTablePreferencesSerializer,
 )
+from timetable.realtime import sync_and_broadcast_shared_timetables_for_source
 from helpers.mixins import ValidateSubdomainMixin, RedirectToSignupMixin
 from helpers.decorators import validate_subdomain
 from semesterly.settings import get_secret
@@ -262,6 +264,9 @@ class UserTimetableView(ValidateSubdomainMixin, RedirectToSignupMixin, APIView):
         self.update_events(
             personal_timetable, request.data["events"]
         )  # events correspond to PersonalEvent model
+        transaction.on_commit(
+            lambda: sync_and_broadcast_shared_timetables_for_source(personal_timetable)
+        )
 
         response = {
             "timetables": get_student_tts(student, school, semester),

--- a/timetable/consumers.py
+++ b/timetable/consumers.py
@@ -1,0 +1,35 @@
+import json
+
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+
+from semesterly.settings import ENABLE_SOCIAL_SYNC_GHOST
+from timetable.realtime import get_shared_timetable_group
+
+
+class SharedTimetableConsumer(AsyncJsonWebsocketConsumer):
+    async def connect(self):
+        if not ENABLE_SOCIAL_SYNC_GHOST:
+            await self.close()
+            return
+        self.slug = self.scope["url_route"]["kwargs"]["slug"]
+        self.group_name = get_shared_timetable_group(self.slug)
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+        await self.send_json(
+            {"type": "connection.ready", "slug": self.slug, "connected": True}
+        )
+
+    async def disconnect(self, close_code):
+        await self.channel_layer.group_discard(self.group_name, self.channel_name)
+
+    async def receive(self, text_data=None, bytes_data=None, **kwargs):
+        if text_data:
+            try:
+                payload = json.loads(text_data)
+            except json.JSONDecodeError:
+                payload = {}
+            if payload.get("type") == "ping":
+                await self.send_json({"type": "pong"})
+
+    async def timetable_update(self, event):
+        await self.send_json(event["payload"])

--- a/timetable/realtime.py
+++ b/timetable/realtime.py
@@ -1,7 +1,9 @@
 from asgiref.sync import async_to_sync
 from django.utils import timezone
 
+from courses.serializers import CourseSerializer
 from semesterly.settings import ENABLE_SOCIAL_SYNC_GHOST
+from timetable.serializers import DisplayTimetableSerializer
 from timetable.share_links import get_shared_timetable_slug
 
 
@@ -9,7 +11,7 @@ def get_shared_timetable_group(slug):
     return f"shared_timetable_{slug}"
 
 
-def _broadcast_shared_timetable_update(slug, updated_at=None):
+def _broadcast_shared_timetable_update(payload):
     try:
         from channels.layers import get_channel_layer
     except ImportError:
@@ -19,17 +21,8 @@ def _broadcast_shared_timetable_update(slug, updated_at=None):
     if channel_layer is None:
         return
 
-    payload = {
-        "type": "timetable.updated",
-        "slug": slug,
-        "updated_at": (
-            updated_at.isoformat()
-            if hasattr(updated_at, "isoformat")
-            else timezone.now().isoformat()
-        ),
-    }
     async_to_sync(channel_layer.group_send)(
-        get_shared_timetable_group(slug),
+        get_shared_timetable_group(payload["slug"]),
         {"type": "timetable_update", "payload": payload},
     )
 
@@ -54,4 +47,23 @@ def sync_and_broadcast_shared_timetables_for_source(source_timetable):
     for shared_timetable in shared_timetables:
         _refresh_shared_timetable_snapshot(shared_timetable, source_timetable)
         slug = get_shared_timetable_slug(shared_timetable)
-        _broadcast_shared_timetable_update(slug, shared_timetable.updated_at)
+        serializer_context = {
+            "semester": shared_timetable.semester,
+            "school": shared_timetable.school,
+            "student": None,
+        }
+        payload = {
+            "type": "timetable.updated",
+            "slug": slug,
+            "permission": shared_timetable.permission,
+            "updatedAt": (
+                shared_timetable.updated_at.isoformat()
+                if hasattr(shared_timetable.updated_at, "isoformat")
+                else timezone.now().isoformat()
+            ),
+            "sharedTimetable": DisplayTimetableSerializer.from_model(shared_timetable).data,
+            "courses": CourseSerializer(
+                shared_timetable.courses, context=serializer_context, many=True
+            ).data,
+        }
+        _broadcast_shared_timetable_update(payload)

--- a/timetable/realtime.py
+++ b/timetable/realtime.py
@@ -1,0 +1,57 @@
+from asgiref.sync import async_to_sync
+from django.utils import timezone
+
+from semesterly.settings import ENABLE_SOCIAL_SYNC_GHOST
+from timetable.share_links import get_shared_timetable_slug
+
+
+def get_shared_timetable_group(slug):
+    return f"shared_timetable_{slug}"
+
+
+def _broadcast_shared_timetable_update(slug, updated_at=None):
+    try:
+        from channels.layers import get_channel_layer
+    except ImportError:
+        return
+
+    channel_layer = get_channel_layer()
+    if channel_layer is None:
+        return
+
+    payload = {
+        "type": "timetable.updated",
+        "slug": slug,
+        "updated_at": (
+            updated_at.isoformat()
+            if hasattr(updated_at, "isoformat")
+            else timezone.now().isoformat()
+        ),
+    }
+    async_to_sync(channel_layer.group_send)(
+        get_shared_timetable_group(slug),
+        {"type": "timetable_update", "payload": payload},
+    )
+
+
+def _refresh_shared_timetable_snapshot(shared_timetable, source_timetable):
+    shared_timetable.school = source_timetable.school
+    shared_timetable.semester = source_timetable.semester
+    shared_timetable.has_conflict = source_timetable.has_conflict
+    shared_timetable.courses.set(source_timetable.courses.all())
+    shared_timetable.sections.set(source_timetable.sections.all())
+    shared_timetable.save()
+
+
+def sync_and_broadcast_shared_timetables_for_source(source_timetable):
+    if not ENABLE_SOCIAL_SYNC_GHOST:
+        return
+    from analytics.models import SharedTimetable
+
+    shared_timetables = SharedTimetable.objects.filter(
+        source_timetable=source_timetable, revoked_at__isnull=True
+    )
+    for shared_timetable in shared_timetables:
+        _refresh_shared_timetable_snapshot(shared_timetable, source_timetable)
+        slug = get_shared_timetable_slug(shared_timetable)
+        _broadcast_shared_timetable_update(slug, shared_timetable.updated_at)

--- a/timetable/share_links.py
+++ b/timetable/share_links.py
@@ -1,0 +1,35 @@
+import re
+
+from django.http import Http404
+from hashids import Hashids
+
+from analytics.models import SharedTimetable
+from semesterly.settings import get_secret
+
+hashids = Hashids(salt=get_secret("HASHING_SALT"))
+HASHID_PATTERN = re.compile(r"^[A-Za-z0-9]+$")
+
+
+def get_shared_timetable_slug(shared_timetable):
+    if shared_timetable.share_token:
+        return shared_timetable.share_token
+    return hashids.encrypt(shared_timetable.id)
+
+
+def resolve_shared_timetable_by_slug(slug, school):
+    by_token = SharedTimetable.objects.filter(share_token=slug, school=school).first()
+    if by_token is not None:
+        return by_token
+
+    if not HASHID_PATTERN.match(slug):
+        raise Http404
+
+    decoded = hashids.decrypt(slug)
+    if not decoded:
+        raise Http404
+
+    timetable_id = decoded[0]
+    try:
+        return SharedTimetable.objects.get(id=timetable_id, school=school)
+    except SharedTimetable.DoesNotExist as exc:
+        raise Http404 from exc

--- a/timetable/tests.py
+++ b/timetable/tests.py
@@ -12,6 +12,8 @@
 
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.utils import timezone
+from unittest.mock import patch
 from rest_framework import status
 from rest_framework.test import APITestCase
 from helpers.test.data import get_default_tt_request
@@ -22,6 +24,7 @@ from timetable.utils import DisplayTimetable
 from timetable.serializers import DisplayTimetableSerializer, EventSerializer
 from student.models import Student, PersonalTimetable, PersonalEvent
 from helpers.test.test_cases import UrlTestCase
+from timetable.realtime import sync_and_broadcast_shared_timetables_for_source
 
 
 class Serializers(TestCase):
@@ -138,6 +141,9 @@ class UrlsTest(UrlTestCase):
         self.assertUrlResolvesToView(
             "/timetables/links/SecAV/", "timetable.views.TimetableLinkView"
         )
+        self.assertUrlResolvesToView(
+            "/timetables/links/SecAV/ghost/", "timetable.views.SharedTimetableGhostView"
+        )
 
 
 class TimetableViewTest(APITestCase):
@@ -182,6 +188,20 @@ class TimetableLinkViewTest(APITestCase):
             time_end="10:00",
             is_short_course=False,
         )
+        self.user = User.objects.create_user(username="tt-owner", password="pw")
+        self.student = Student.objects.create(user=self.user, school="uoft")
+        self.personal_timetable = PersonalTimetable.objects.create(
+            name="My Schedule",
+            school="uoft",
+            semester=sem,
+            student=self.student,
+            has_conflict=False,
+        )
+        self.personal_timetable.courses.add(course)
+        self.personal_timetable.sections.add(section)
+        self.sem = sem
+        self.course = course
+        self.section = section
 
     def test_create_then_get_link(self):
         data = {
@@ -195,13 +215,53 @@ class TimetableLinkViewTest(APITestCase):
             "/timetables/links/", data, format="json", **self.request_headers
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("slug", response.data)
 
+    def test_ghost_endpoint_returns_timetable_payload(self):
+        data = {
+            "timetable": {
+                "id": self.personal_timetable.id,
+                "slots": [{"course": 1, "section": 1, "offerings": []}],
+                "has_conflict": False,
+            },
+            "semester": {"name": "Fall", "year": "2000"},
+        }
+        self.client.force_authenticate(self.user)
+        response = self.client.post(
+            "/timetables/links/", data, format="json", **self.request_headers
+        )
         slug = response.data["slug"]
-
-        # assumes that the response will be a 404 if post did not actually
-        # create a shared timetable
         response = self.client.get(
-            "/timetables/links/{}/".format(slug), **self.request_headers
+            "/timetables/links/{}/ghost/".format(slug), **self.request_headers
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["slug"], slug)
+        self.assertIn("sharedTimetable", response.data)
+        self.assertIn("courses", response.data)
+
+    def test_revoked_or_expired_share_is_not_accessible(self):
+        shared = SharedTimetable.objects.create(
+            school="uoft",
+            semester=self.sem,
+            has_conflict=False,
+            revoked_at=timezone.now(),
+        )
+        shared.courses.add(self.course)
+        shared.sections.add(self.section)
+        shared.ensure_share_token()
+        response = self.client.get(
+            "/timetables/links/{}/ghost/".format(shared.share_token),
+            **self.request_headers
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_sync_broadcast_on_personal_timetable_update(self):
+        shared = SharedTimetable.objects.create(
+            school="uoft",
+            semester=self.sem,
+            has_conflict=False,
+            source_timetable=self.personal_timetable,
+        )
+        shared.ensure_share_token()
+        with patch("timetable.realtime._broadcast_shared_timetable_update") as mocked:
+            sync_and_broadcast_shared_timetables_for_source(self.personal_timetable)
+            self.assertTrue(mocked.called)

--- a/timetable/urls.py
+++ b/timetable/urls.py
@@ -30,6 +30,10 @@ urlpatterns = [
     # sharing
     re_path(r"^timetables/links/$", timetable.views.TimetableLinkView.as_view()),
     re_path(
+        r"^timetables/links/(?P<slug>.+)/ghost/$",
+        timetable.views.SharedTimetableGhostView.as_view(),
+    ),
+    re_path(
         r"^timetables/links/(?P<slug>.+)/$", timetable.views.TimetableLinkView.as_view()
     ),
     re_path(  # maintain backwards compatibility

--- a/timetable/views.py
+++ b/timetable/views.py
@@ -14,8 +14,8 @@
 import itertools
 import logging
 
-from django.shortcuts import get_object_or_404
-from hashids import Hashids
+from django.utils import timezone
+from django.http import Http404
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -26,14 +26,17 @@ from courses.serializers import CourseSerializer
 from student.utils import get_student
 from timetable.serializers import DisplayTimetableSerializer
 from timetable.models import Semester, Course, Section
+from timetable.share_links import (
+    get_shared_timetable_slug,
+    resolve_shared_timetable_by_slug,
+)
 from timetable.utils import (
     update_locked_sections,
     courses_to_timetables,
 )
 from helpers.mixins import ValidateSubdomainMixin, FeatureFlowView, CsrfExemptMixin
-from semesterly.settings import get_secret
+from semesterly.settings import ENABLE_SOCIAL_SYNC_GHOST
 
-hashids = Hashids(salt=get_secret("HASHING_SALT"))
 logger = logging.getLogger(__name__)
 
 
@@ -140,10 +143,9 @@ class TimetableLinkView(FeatureFlowView):
         decrypts the hashed database id, and either retrieves the corresponding
         timetable or hits a 404.
         """
-        timetable_id = hashids.decrypt(slug)[0]
-        shared_timetable = get_object_or_404(
-            SharedTimetable, id=timetable_id, school=request.subdomain
-        )
+        shared_timetable = resolve_shared_timetable_by_slug(slug, request.subdomain)
+        if not self.is_share_access_valid(shared_timetable):
+            raise Http404
         context = {
             "semester": shared_timetable.semester,
             "school": request.subdomain,
@@ -169,12 +171,38 @@ class TimetableLinkView(FeatureFlowView):
         has_conflict = timetable.get("has_conflict", False)
         semester, _ = Semester.objects.get_or_create(**request.data["semester"])
         student = get_student(request)
+        source_timetable = None
+        timetable_id = timetable.get("id")
+        if student is not None and timetable_id:
+            source_timetable = (
+                student.personaltimetable_set.filter(
+                    id=timetable_id, school=school, semester=semester
+                ).first()
+            )
+        if source_timetable is None and student is not None:
+            # Fallback for legacy clients that omit timetable id in share payload.
+            source_timetable = (
+                student.personaltimetable_set.filter(
+                    school=school, semester=semester
+                )
+                .order_by("-last_updated")
+                .first()
+            )
+        permission = request.data.get("permission", "view")
+        if permission not in {"view", "edit"}:
+            permission = "view"
         shared_timetable = SharedTimetable.objects.create(
-            student=student, school=school, semester=semester, has_conflict=has_conflict
+            student=student,
+            school=school,
+            semester=semester,
+            has_conflict=has_conflict,
+            source_timetable=source_timetable,
+            permission=permission,
         )
         shared_timetable.save()
         self.save_courses(timetable, shared_timetable)
-        response = {"slug": hashids.encrypt(shared_timetable.id)}
+        shared_timetable.ensure_share_token()
+        response = {"slug": get_shared_timetable_slug(shared_timetable)}
         return Response(response, status=status.HTTP_200_OK)
 
     def save_courses(self, timetable: dict, shared_timetable: SharedTimetable):
@@ -191,3 +219,51 @@ class TimetableLinkView(FeatureFlowView):
             if section_obj.course.id not in added_courses:
                 return Response(status=status.HTTP_400_BAD_REQUEST)
         shared_timetable.save()
+
+    def is_share_access_valid(self, shared_timetable):
+        if shared_timetable.revoked_at is not None:
+            return False
+        if (
+            shared_timetable.expires_at is not None
+            and shared_timetable.expires_at <= timezone.now()
+        ):
+            return False
+        return True
+
+
+class SharedTimetableGhostView(ValidateSubdomainMixin, APIView):
+    """
+    Read-only API for loading a shared timetable as a ghost overlay.
+    """
+
+    def get(self, request, slug):
+        if not ENABLE_SOCIAL_SYNC_GHOST:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        shared_timetable = resolve_shared_timetable_by_slug(slug, request.subdomain)
+        if not self._is_share_access_valid(shared_timetable):
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        context = {
+            "semester": shared_timetable.semester,
+            "school": request.subdomain,
+            "student": get_student(request),
+        }
+        response = {
+            "slug": get_shared_timetable_slug(shared_timetable),
+            "permission": shared_timetable.permission,
+            "updatedAt": shared_timetable.updated_at.isoformat(),
+            "sharedTimetable": DisplayTimetableSerializer.from_model(shared_timetable).data,
+            "courses": CourseSerializer(
+                shared_timetable.courses, context=context, many=True
+            ).data,
+        }
+        return Response(response, status=status.HTTP_200_OK)
+
+    def _is_share_access_valid(self, shared_timetable):
+        if shared_timetable.revoked_at is not None:
+            return False
+        if (
+            shared_timetable.expires_at is not None
+            and shared_timetable.expires_at <= timezone.now()
+        ):
+            return False
+        return True


### PR DESCRIPTION
## Why this change
The original ghost-share flow only refreshed after manual reload (or polling fallback), so shared timetable viewers could miss changes while the owner edited their schedule. This update moves the feature to true push-based updates so ghost overlays behave more like collaborative documents: once a viewer opens a share link, updates appear automatically.

To support real-time updates end-to-end, we also needed to run Django in an ASGI-capable server path instead of WSGI-only dev flow.

## How we implemented it
- switched the web runtime to **Uvicorn + ASGI** so HTTP and WebSocket traffic are both handled by Django in one app lifecycle
- added **Django Channels + Redis channel layer** for fan-out messaging from timetable updates to all viewers subscribed to a shared link room
- updated reverse proxy rules in **Caddy** to explicitly upgrade and forward `/ws/...` connections, which is required for browser WebSocket handshakes
- wrapped ASGI app with `ASGIStaticFilesHandler` so static assets continue to load correctly in local ASGI development

## Major backend changes
- extended `SharedTimetable` with social-sync metadata (`share_token`, `source_timetable`, permission/expiry/revoke fields, `updated_at`) and migration
- introduced share-link utilities to support **new token slugs** while remaining backward-compatible with existing hashid links
- added a ghost-read API endpoint (`/timetables/links/<slug>/ghost/`) with access validation and school scoping
- implemented realtime sync module + Channels consumer:
  - on `PersonalTimetable` save, refresh linked shared snapshots
  - publish `timetable.updated` events to the corresponding share room after transaction commit

## Major frontend changes
- added ghost overlay Redux slice + async actions for initial ghost fetch and WebSocket lifecycle
- added ghost WebSocket endpoint handling and state updates on `timetable.updated`
- updated calendar rendering to support conflict-aware ghost blocks (side-by-side for overlaps)
- updated ghost slot UI to show richer details aligned with normal slots: **course name + section + time + location**

## Infra/config changes
- `docker-compose`: add Redis service and run web with Uvicorn ASGI app
- `semesterly/settings.py`: configure Channels + channel layers + feature flag for ghost mode rollout
- `build/caddy/Caddyfile`: add explicit websocket proxy route for `/ws`

## Test plan
- [x] `docker compose up --build` and verify app loads under ASGI with static assets
- [x] enable ghost mode using a share link and verify ghost classes render with conflict layout/details
- [x] update source timetable in another tab/account and verify viewer ghost overlay updates without page refresh
- [x] run `docker compose exec web python manage.py test timetable.tests`
- [x] run frontend tests including `ghost_timetable_slice.test.ts`